### PR TITLE
Fix log out not working

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -2934,6 +2934,15 @@ var SettingsController = (function () {
             } else {
                newOkBtn.focus();
             }
+         } else if (evt.keyCode === KeyCodes.ENTER) {
+            evt.preventDefault();
+            // Trigger click on the focused button (Confirm or Cancel)
+            if (
+               document.activeElement === newOkBtn ||
+               document.activeElement === newCancelBtn
+            ) {
+               document.activeElement.click();
+            }
          }
       };
 


### PR DESCRIPTION
This pr fixes #19, it includes 2 fixes: 

First: The code in settings.js was trying to use Logger.info, but Logger is not defined globally (it's internal to jellyfin-api.js). This caused a Reference Error, which crashed the script before it could execute the redirect line.

This uses console.log instead and wraps the whole thing in a try-catch block for extra safety.

Second: The buttons in the sign-out dialog weren't triggered by the enter button on the remote, fixed by adding it to the control handling!

Tested on my Tv with Tizen 5.5✌️.