### PR TITLE
fallback to extracted subtitles if native embedded subtitles found none

### DIFF
--- a/src/services/tizenVideo.js
+++ b/src/services/tizenVideo.js
@@ -404,6 +404,18 @@ export const avplaySetDrm = (drmType, operation, drmData) => {
 	webapis.avplay.setDrm(drmType, operation, drmData);
 };
 
+export const avplayGetTracks = () => {
+	if (!isAVPlayAvailable) return [];
+	try {
+		const trackInfo = webapis.avplay.getTotalTrackInfo();
+		console.log('[tizenVideo] Track Info:', JSON.stringify(trackInfo));
+		return trackInfo;
+	} catch (e) {
+		console.warn('[tizenVideo] Failed to get track info:', e);
+		return [];
+	}
+};
+
 export const avplaySelectTrack = (type, index) => {
 	if (!isAVPlayAvailable) return;
 	try {
@@ -585,5 +597,6 @@ export default {
 	avplaySetSpeed,
 	avplaySetDrm,
 	avplaySelectTrack,
-	avplaySetSilentSubtitle
+	avplaySetSilentSubtitle,
+	avplayGetTracks
 };


### PR DESCRIPTION
## Summary
This fixes subtitles failing to render in the last version, since we are not using avplay, trying to play embedded subs fails because it finds 0 tracks, this makes it fall back to extracted subs if that happens.

## Type of Change
- [x] Bug fix

## Testing

- [x] Tested on physical device

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [ ] No new warnings introduced
- [ ] Documentation updated (if needed)

## Test Build

[Moonfin-v2.0.0.zip](https://github.com/user-attachments/files/25186063/Moonfin-v2.0.0.zip)
