### PR TITLE
fix: prevent cards being cut off with 'start' scroll behavior

### DIFF
--- a/src/views/Browse/Browse.js
+++ b/src/views/Browse/Browse.js
@@ -272,7 +272,7 @@ const Browse = ({
 		Spotlight.focus(`row-${targetIndex}`);
 		const targetRow = document.querySelector(`[data-row-index="${targetIndex}"]`);
 		if (targetRow) {
-			targetRow.scrollIntoView({block: 'center'});
+			targetRow.scrollIntoView({block: 'start'});
 		}
 	}, [filteredRows.length]);
 
@@ -288,7 +288,7 @@ const Browse = ({
 
 					const targetRow = document.querySelector(`[data-row-index="${targetRowIndex}"]`);
 					if (targetRow) {
-						targetRow.scrollIntoView({block: 'center'});
+						targetRow.scrollIntoView({block: 'start'});
 					}
 					lastFocusState = null;
 				}
@@ -808,6 +808,13 @@ const Browse = ({
 				const contentRows = document.querySelector('[data-element="content-rows"]');
 				if (contentRows) contentRows.scrollTop = 0;
 				Spotlight.focus('row-0');
+				// Ensure row is at top for TizenOS
+				setTimeout(() => {
+					const firstRow = document.querySelector('[data-row-index="0"]');
+					if (firstRow) {
+						firstRow.scrollIntoView({block: 'start', behavior: 'auto'});
+					}
+				}, 50);
 			}, TRANSITION_DELAY_MS);
 		}
 	}, [handleFeaturedPrev, handleFeaturedNext]);


### PR DESCRIPTION
# Pull Request

## Summary
Prevent cards to be cut off when scrolling on Tizen (was not appearing in dev)

## Type of Change
- [x] Bug fix
- [x] UI/UX update

## Changes Made
- Changed `scrollIntoView()` alignment from 'center' to 'start' in row focus handlers to prevent card cutoff
- Added explicit scroll positioning with small delay for first row after featured section collapse on Tizen

## Testing
- [x] Tested on emulator
- [ ] Tested on physical device
- [x] Manual testing completed

## Screenshots
Before: 
<img width="1089" height="557" alt="Capture d&#39;écran 2026-02-12 220954" src="https://github.com/user-attachments/assets/ad950e3d-2ff4-4f1b-b496-0b8d2bc133da" />

After:
<img width="1064" height="553" alt="Capture d&#39;écran 2026-02-12 215149" src="https://github.com/user-attachments/assets/468f844a-fbf9-4fa1-9e54-28b81c752f41" />


### Test Steps
1. Navigate to Browse view
2. Scroll through different media rows
3. Switch between featured content and library rows
4. Verify cards are not cut off at bottom of scroll container
5. Test on Tizen TV emulator to confirm TizenOS-specific behavior works correctly