### PR TITLE
fix: include user ID in cache to ensure per-user data & redirect to Browse on user change

### DIFF
--- a/packages/app/src/components/ExitDialog/ExitDialog.js
+++ b/packages/app/src/components/ExitDialog/ExitDialog.js
@@ -27,9 +27,8 @@ const exitApp = () => {
 const ExitDialog = ({open, onCancel, onExit}) => {
 	useEffect(() => {
 		if (open) {
-			window.requestAnimationFrame(() => {
-				Spotlight.focus('exit-cancel-btn');
-			});
+			const t = setTimeout(() => Spotlight.focus('exit-cancel-btn'), 100);
+			return () => clearTimeout(t);
 		}
 	}, [open]);
 


### PR DESCRIPTION
# Pull Request

## Summary
Scope browse cache data per user by storing and validating "userId", ensuring each user sees their own Continue Watching for example.

## Type of Change
- [x] Bug fix

## Changes Made
- Store "userId" alongside "serverUrl" in the browse cache payload.
- Validate cache reads against both "serverUrl" and "userId".
- Redirect to Browse panel on user switch by comparing previous and current userId.

## Testing
- [x] Tested on emulator

### Test Steps
1. Switch user.
2. Ensure “Continue Watching” matches the selected user.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
