### PR TITLE
Update App.js for correct reopen handling

### DIFF
--- a/packages/app/src/App/App.js
+++ b/packages/app/src/App/App.js
@@ -205,6 +205,9 @@ const AppContent = (props) => {
 			if (isAuthenticated) {
 				setPanelIndex(PANELS.BROWSE);
 			}
+			if (isWebOS()) {
+				window.webOSSystem.activate();
+			}
 		};
 
 		window.addEventListener('beforeunload', handleBeforeUnload);


### PR DESCRIPTION
# Pull Request

## Summary
With this change you can normally reopen the app. Again because other repo moved.

## Related Issues
Not in this repo

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
Webossystem.activate needs to be called for the app to become visible again.

## Platform
- [ ] Tizen (Samsung)
- [x] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open app
2. Switch to tv or any other app
3. Try to reopen the app
