### PR TITLE
Update WebOSPlayer.js play/pause on button click

### DIFF
--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -1463,7 +1463,13 @@ const Player = ({item, resume, initialAudioIndex, initialSubtitleIndex, onEnded,
 				handleBack();
 				return;
 			}
-
+			
+			if ((key === 'Enter' || e.keyCode === 13) && !controlsVisible && !showSkipIntro && !showSkipCredits && !showNextEpisode) {
+				e.preventDefault();
+				handlePlayPause();
+				return;
+			}
+			
 			// Left/Right when controls hidden -> show controls and focus on seekbar
 			if (!controlsVisible && !activeModal) {
 				if (key === 'ArrowLeft' || e.keyCode === 37 || key === 'ArrowRight' || e.keyCode === 39) {
@@ -1516,10 +1522,6 @@ const Player = ({item, resume, initialAudioIndex, initialSubtitleIndex, onEnded,
 				}
 			}
 
-			if ((key === 'Enter' || e.keyCode === 13) && !controlsVisible && !showSkipIntro && !showSkipCredits && !showNextEpisode) {
-				handlePlayPause();
-				return;
-			}
 		};
 
 		window.addEventListener('keydown', handleKeyDown, true);


### PR DESCRIPTION
# Pull Request

## Summary
The if block for pause was never reached and the block before just opened the controls. Moved the if block and added preventdefault so it doesn't restart playback again.

## Related Issues
none

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- moved the if block a few lines higher
- added e.preventDefault() 

## Platform
- [ ] Tizen (Samsung)
- [x] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start playback
2. Press Enter key on Remote
3. Playback should stop

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
