### PR TITLE
Opacity for User Avatar

### DIFF
--- a/packages/app/src/components/NavBar/NavBar.js
+++ b/packages/app/src/components/NavBar/NavBar.js
@@ -117,6 +117,12 @@ const NavBar = ({
 		setAvatarError(true);
 	}, []);
 
+	const userAvatarStyle = useMemo(() => {
+		return {
+			opacity: (settings.userOpacity ?? 85) / 100
+		};
+	}, [settings.userOpacity]);
+
 	const handleLibraryClick = useCallback((e) => {
 		const libId = e.currentTarget.dataset.libraryId;
 		const lib = libraries.find(l => l.Id === libId);
@@ -193,10 +199,11 @@ const NavBar = ({
 							className={css.userAvatarImg}
 							src={userAvatarUrl}
 							alt={user?.Name}
+							style={userAvatarStyle}
 							onError={handleAvatarError}
 						/>
 					) : (
-						<div className={css.userAvatar}>{user?.Name?.[0] || 'U'}</div>
+						<div className={css.userAvatar} style={userAvatarStyle}>{user?.Name?.[0] || 'U'}</div>
 					)}
 				</SpottableButton>
 			</div>

--- a/packages/app/src/views/Settings/Settings.js
+++ b/packages/app/src/views/Settings/Settings.js
@@ -164,6 +164,15 @@ const UI_OPACITY_OPTIONS = [
 	{value: 95, label: '95%'}
 ];
 
+const USER_OPACITY_OPTIONS = [
+	{value: 0, label: '0%'},
+	{value: 50, label: '50%'},
+	{value: 65, label: '65%'},
+	{value: 75, label: '75%'},
+	{value: 85, label: '85%'},
+	{value: 95, label: '95%'}
+];
+
 const UI_COLOR_OPTIONS = [
 	{value: 'dark', label: 'Dark Gray', rgb: '40, 40, 40'},
 	{value: 'black', label: 'Black', rgb: '0, 0, 0'},
@@ -878,6 +887,11 @@ const Settings = ({onBack, onLibrariesChanged}) => {
 					getLabel(UI_OPACITY_OPTIONS, settings.uiOpacity, '85%'),
 					() => openOptionDialog('UI Opacity', UI_OPACITY_OPTIONS, 'uiOpacity'),
 					'setting-uiOpacity'
+				)}
+				{renderSettingItem('User Avatar Opacity', 'Opacity of User Avatar on top left',
+					getLabel(USER_OPACITY_OPTIONS, settings.userOpacity, '85%'),
+					() => openOptionDialog('User Avatar Opacity', USER_OPACITY_OPTIONS, 'userOpacity'),
+					'setting-userOpacity'
 				)}
 				{renderSettingItem('UI Color', 'Background color of navbar and UI panels',
 					getLabel(UI_COLOR_OPTIONS, settings.uiColor, 'Dark Gray'),


### PR DESCRIPTION
# Pull Request

## Summary
The guy yesterday hated clocks, i hate the user avatar. Let's give the user the possibility to hide that while maintaining the functionality behind it😁

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- option to change opacity of the user icon

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Change opacity in settings
2. Opacity changed

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
