### PR TITLE
fix: include user ID in cache to ensure per-user data & redirect t Browse on user change

### DIFF
--- a/packages/app/src/App/App.js
+++ b/packages/app/src/App/App.js
@@ -98,6 +98,7 @@ const AppContent = (props) => {
 	const backHandlerRef = useRef(null);
 	const detailsItemStackRef = useRef([]);
 	const jellyseerrItemStackRef = useRef([]);
+	const prevUserIdRef = useRef(null);
 	const [photoViewerItem, setPhotoViewerItem] = useState(null);
 	const [photoViewerItems, setPhotoViewerItems] = useState([]);
 	const [comicViewerItem, setComicViewerItem] = useState(null);
@@ -248,6 +249,20 @@ const AppContent = (props) => {
 			}
 		};
 	}, [isAuthenticated, performAppCleanup]);
+
+	useEffect(() => {
+		if (!isAuthenticated || !user?.Id) {
+			prevUserIdRef.current = null;
+			return;
+		}
+
+		if (user.Id !== prevUserIdRef.current) {
+			prevUserIdRef.current = user.Id;
+			setPanelHistory([]);
+			setPanelIndex(PANELS.BROWSE);
+		}
+	}, [user?.Id, isAuthenticated]);
+
 
 	useEffect(() => {
 		if (!isLoading && !authChecked) {

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -47,7 +47,7 @@ const Browse = ({
 	onSelectLibrary,
 	isVisible = true
 }) => {
-	const {api, serverUrl, accessToken, hasMultipleServers} = useAuth();
+	const {api, serverUrl, accessToken, hasMultipleServers, user} = useAuth();
 	const {settings} = useSettings();
 	const unifiedMode = settings.unifiedLibraryMode && hasMultipleServers;
 	const [isLoading, setIsLoading] = useState(true);
@@ -389,26 +389,27 @@ const Browse = ({
 				libraries: libs,
 				featuredItems: featured,
 				timestamp: Date.now(),
-				serverUrl
+				serverUrl,
+				userId: user?.Id || null
 			};
 			await saveToStorage(STORAGE_KEY_BROWSE, cacheData);
 		} catch (e) {
 			console.warn('[Browse] Failed to save cache:', e);
 		}
-	}, [serverUrl]);
+	}, [serverUrl, user?.Id]);
 
 	// Load browse data from persistent storage
 	const loadBrowseCache = useCallback(async () => {
 		try {
 			const cached = await getFromStorage(STORAGE_KEY_BROWSE);
-			if (cached && cached.serverUrl === serverUrl) {
+			if (cached && cached.serverUrl === serverUrl && cached.userId === (user?.Id || null)) {
 				return cached;
 			}
 		} catch (e) {
 			console.warn('[Browse] Failed to load cache:', e);
 		}
 		return null;
-	}, [serverUrl]);
+	}, [serverUrl, user?.Id]);
 
 	useEffect(() => {
 		const loadData = async () => {


### PR DESCRIPTION
# Pull Request

## Summary
Scope browse cache data per user by storing and validating "userId", ensuring each user sees their own Continue Watching for example.

## Type of Change
- [x] Bug fix

## Changes Made
- Store "userId" alongside "serverUrl" in the browse cache payload.
- Validate cache reads against both "serverUrl" and "userId".
- Redirect to Browse panel on user switch by comparing previous and current userId.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
- [x] Tested on emulator
- [x] Tested on physical device

### Test Steps
1. Switch user.
2. Ensure “Continue Watching” matches the selected user.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
