### PR TITLE
style: better progress bar on MediaCard

### DIFF
--- a/packages/app/src/components/MediaCard/MediaCard.module.less
+++ b/packages/app/src/components/MediaCard/MediaCard.module.less
@@ -80,13 +80,27 @@
 	background: #2a2a4e;
 	font-size: 64px;
 	color: #666;
-	border-radius: 8px;
+	border-radius: 20px;
 	border: 4px solid transparent;
 	box-sizing: border-box;
 }
 
 .imageContainer {
 	position: relative;
+	border-radius: 20px;
+	overflow: hidden;
+
+	&::after {
+		content: '';
+		position: absolute;
+		bottom: 4px;
+		left: 4px;
+		right: 4px;
+		height: 30%;
+		background: linear-gradient(to top, rgba(0, 0, 0, 0.75) 0%, transparent 100%);
+		pointer-events: none;
+		border-radius: 0 0 16px 16px;
+	}
 }
 
 .info {
@@ -123,19 +137,24 @@
 
 .progressBar {
 	position: absolute;
-	bottom: 0;
-	left: 0;
-	width: 100%;
-	height: 6px;
-	background: rgba(0, 0, 0, 0.6);
-	border-radius: 0 0 8px 8px;
+	bottom: 14px;
+	left: 30px;
+	right: 30px;
+	width: auto;
+	height: 8px;
+	background: rgba(100, 100, 100, 0.7);
+	border-radius: 999px;
 	overflow: hidden;
+	backdrop-filter: blur(4px);
+	-webkit-backdrop-filter: blur(4px);
+	z-index: 1;
 }
 
 .progress {
 	height: 100%;
-	background: @accent;
-	transition: width 0.3s ease;
+	background: rgb(255, 255, 255);
+	transition: width 0.25s ease;
+	border-radius: inherit;
 }
 
 .serverBadge {


### PR DESCRIPTION
# Pull Request

## Summary
Better progress bar UI on MediaCard

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Fixed progress bar overflowing outside the card's
- Better UI (gradient behind progress bar, better color for UX)

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing

- [x] Tested on emulator
- [ ] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Browse any library with partially watched episodes or movies

## Screenshots (if applicable)
Before:
<img width="636" height="429" alt="image" src="https://github.com/user-attachments/assets/a639f17a-8d63-499b-9a81-b0885cefdb75" />
After:
<img width="634" height="425" alt="image" src="https://github.com/user-attachments/assets/8f63ba5d-0401-4664-9e31-14d0e5cbf063" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced