### PR TITLE
Featured banner timer fix

### DIFF
--- a/packages/app/src/views/Browse/Browse.module.less
+++ b/packages/app/src/views/Browse/Browse.module.less
@@ -100,8 +100,6 @@
 	outline: none;
 }
 
-
-
 .featuredBackdrop {
 	position: absolute;
 	top: 0;

--- a/packages/app/src/views/Browse/FeaturedBanner.js
+++ b/packages/app/src/views/Browse/FeaturedBanner.js
@@ -38,6 +38,7 @@ const FeaturedBanner = memo(({
 	const trailerVideoIdRef = useRef(null);
 	const trailerRevealTimerRef = useRef(null);
 	const sponsorSegmentsRef = useRef([]);
+	const carouselIntervalRef = useRef(null);
 
 	const currentFeatured = featuredItems[currentIndex];
 
@@ -77,15 +78,29 @@ const FeaturedBanner = memo(({
 		}
 	}, [currentIndex, featuredItems, serverUrl]);
 
-	useEffect(() => {
+	const startCarouselTimer = useCallback(() => {
+		if (carouselIntervalRef.current) {
+			clearInterval(carouselIntervalRef.current);
+			carouselIntervalRef.current = null;
+		}
+
 		const carouselSpeed = settings.carouselSpeed || 8000;
 		if (!isVisible || featuredItems.length <= 1 || !featuredFocused || carouselSpeed === 0 || trailerActive) return;
 
-		const interval = setInterval(() => {
+		carouselIntervalRef.current = setInterval(() => {
 			setCurrentIndex((prev) => (prev + 1) % featuredItems.length);
 		}, carouselSpeed);
+	}, [isVisible, featuredItems.length, featuredFocused, settings.carouselSpeed, trailerActive]);
 
-		return () => clearInterval(interval);
+	useEffect(() => {
+	  if (!isVisible || featuredItems.length <= 1 || !featuredFocused || settings.carouselSpeed === 0 || trailerActive) return;
+		startCarouselTimer();
+		return () => {
+		  if (carouselIntervalRef.current) {
+       	clearInterval(carouselIntervalRef.current);
+       	carouselIntervalRef.current = null;
+			}
+		}
 	}, [isVisible, featuredItems.length, featuredFocused, settings.carouselSpeed, trailerActive]);
 
 	const stopTrailer = useCallback(async () => {
@@ -244,14 +259,16 @@ const FeaturedBanner = memo(({
 		setCurrentIndex((prev) =>
 			prev === 0 ? featuredItems.length - 1 : prev - 1
 		);
-	}, [featuredItems.length]);
+		startCarouselTimer();
+	}, [featuredItems.length, startCarouselTimer]);
 
 	const handleFeaturedNext = useCallback(() => {
 		if (featuredItems.length <= 1) return;
 		setCurrentIndex((prev) =>
 			(prev + 1) % featuredItems.length
 		);
-	}, [featuredItems.length]);
+		startCarouselTimer();
+	}, [featuredItems.length, startCarouselTimer]);
 
 	const handleFeaturedKeyDown = useCallback((e) => {
 		if (e.keyCode === KEYS.LEFT) {


### PR DESCRIPTION
# Pull Request

## Summary
Now the 8s or user defined timer restarts when the user imteracts with the featured slider instead of doing next after fixed 8s

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- interval replaced with carouselIntervalRef
- function added to start the timer
- handleprev/next now calls the function to start the timer after switch

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. on featured banner click next
2. after default 8s it skips to next one
3. done

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
