### PR TITLE
Fix: forceDirectPlay not working on Tizen

### DIFF
--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -328,6 +328,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 					startPositionTicks: startPosition,
 					maxBitrate: effectiveBitrate,
 					preferTranscode: settings.preferTranscode,
+					forceDirectPlay: settings.forceDirectPlay,
 					item: item,
 					mediaSourceId: initialMediaSourceId,
 					audioStreamIndex: initialAudioIndex != null ? initialAudioIndex : undefined
@@ -609,7 +610,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			pendingSeekMsRef.current = null;
 		};
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [item, resume, selectedQuality, settings.maxBitrate, settings.preferTranscode, settings.subtitleMode, settings.skipIntro]);
+	}, [item, resume, selectedQuality, settings.maxBitrate, settings.preferTranscode, settings.forceDirectPlay, settings.subtitleMode, settings.skipIntro]);
 
 	// ==============================
 	// Controls Auto-hide


### PR DESCRIPTION
# Pull Request

## Summary
'forceDirectPlay' was already implemented for webOS but was never connected in the Tizen player. This PR passes 'settings.forceDirectPlay' to 'getPlaybackInfo' in 'TizenPlayer.js' and adds it to the effect dependency array, bringing Tizen to parity with webOS.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Passed 'forceDirectPlay: settings.forceDirectPlay' to 'playback.getPlaybackInfo()' in 'TizenPlayer.js'
- Added 'settings.forceDirectPlay' to the playback effect dependency array so the player reinitialises when the setting is toggled.

## Platform
- [x] Tizen (Samsung)
- [ ] webOS (LG)
- [ ] Both / Shared code

## Testing
- [ ] Tested on emulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Settings and enable Force Direct Play
2. Play a video on a Samsung TV
3. Confirm the player uses DirectPlay (check server logs — no transcode session should be started)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
