### PR TITLE
fix: handle gzip-compressed responses in jellyfinApi

### DIFF
--- a/packages/app/src/services/jellyfinApi.js
+++ b/packages/app/src/services/jellyfinApi.js
@@ -101,8 +101,9 @@ const request = async (endpoint, options = {}) => {
 		return null;
 	}
 
-	const buf = await response.arrayBuffer();
-	return JSON.parse(new TextDecoder('utf-8').decode(buf));
+	const text = await response.text();
+	if (!text) return null;
+	return JSON.parse(text);
 };
 
 export const api = {
@@ -422,8 +423,9 @@ export const createApiForServer = (serverUrl, token, userId) => {
 			return null;
 		}
 
-		const buf = await response.arrayBuffer();
-		return JSON.parse(new TextDecoder('utf-8').decode(buf));
+		const text = await response.text();
+		if (!text) return null;
+		return JSON.parse(text);
 	};
 
 	return {

--- a/packages/app/src/views/Login/Login.js
+++ b/packages/app/src/views/Login/Login.js
@@ -64,6 +64,9 @@ const Login = ({
 		try {
 			jellyfinApi.setServer(serverUrl);
 			const info = await jellyfinApi.api.getPublicInfo();
+			if (!info) {
+				throw new Error('Server returned empty response - check if server is reachable');
+			}
 			setServerInfo(info);
 			setStatus(`Connected to ${info.ServerName}! Loading users...`);
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes SyntaxError: Unexpected end of input when connecting to Jellyfin servers that return gzip-compressed responses.
The request functions used response.arrayBuffer() + TextDecoder() which does NOT automatically decompress gzip-encoded responses. Changed to response.text() which handles decompression transparently.
Also added null check for empty responses to prevent null.ServerName crash.

## Related Issues
- Fixes #144 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

1. Fixed gzip response handling in jellyfinApi.js
   - Changed response.arrayBuffer() + TextDecoder() to response.text() in both request and serverRequest functions
   - Added null check for empty responses
2. Added null check in Login.js
   - Added validation to prevent crash on null.ServerName when server returns empty response

## Platform
- [ ] Tizen (Samsung)
- [x] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [x] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch the app on a webOS Smart TV
2. On the login screen, enter a Jellyfin server URL that returns gzip-compressed responses
3. Click "Connect"
4. Expected (before fix): SyntaxError: Unexpected end of input error
5. Expected (after fix): Successfully connects and shows user list

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
