### PR TITLE
Fix/legacy tizen jellyseerr media

### DIFF
--- a/packages/app/src/platform.js
+++ b/packages/app/src/platform.js
@@ -19,3 +19,11 @@ export const getPlatform = () => {
 	if (isTizen()) return 'tizen';
 	return 'unknown';
 };
+
+export const isLegacyTizen = () => {
+	if (!isTizen() || typeof navigator === 'undefined') return false;
+	const match = (navigator.userAgent || '').match(/Tizen\s([0-9]+(?:\.[0-9]+)?)/i);
+	if (!match) return true;
+	const version = parseFloat(match[1]);
+	return !Number.isFinite(version) || version <= 3.0;
+};

--- a/packages/app/src/services/jellyseerrApi.js
+++ b/packages/app/src/services/jellyseerrApi.js
@@ -10,7 +10,7 @@ let jellyfinAccessToken = null;
 
 // webOS 4 and legacy Tizen builds (<=3.0) can fail HTTPS validation for image.tmdb.org,
 // so use HTTP on those devices.
-const shouldUseHttp = () => isWebOS() || isLegacyTizen();
+const shouldUseHttp = isWebOS() || isLegacyTizen();
 
 export const setConfig = (url, user) => {
 jellyseerrUrl = url?.replace(/\/+$/, '');
@@ -651,7 +651,7 @@ return getTv(tmdbId);
 
 export const getImageUrl = (path, size = 'w500') => {
 if (!path) return null;
-const proto = shouldUseHttp() ? 'http' : 'https';
+const proto = shouldUseHttp ? 'http' : 'https';
 const normalizedPath = String(path).trim();
 
 if (!normalizedPath) return null;

--- a/packages/app/src/services/jellyseerrApi.js
+++ b/packages/app/src/services/jellyseerrApi.js
@@ -1,4 +1,4 @@
-import {isWebOS} from '../platform';
+import {isWebOS, isTizen} from '../platform';
 
 let jellyseerrUrl = null;
 let userId = null;
@@ -7,9 +7,17 @@ let moonfinMode = false;
 let jellyfinServerUrl = null;
 let jellyfinAccessToken = null;
 
-// webOS 4's outdated SSL certs can't validate image.tmdb.org over HTTPS,
-// so use HTTP there. Tizen works fine with HTTPS.
-const _useHttp = isWebOS();
+const isLegacyTizen = () => {
+if (!isTizen() || typeof navigator === 'undefined') return false;
+const match = (navigator.userAgent || '').match(/Tizen\s([0-9]+(?:\.[0-9]+)?)/i);
+if (!match) return false;
+const version = parseFloat(match[1]);
+return Number.isFinite(version) && version <= 2.4;
+};
+
+// webOS 4 and legacy Tizen builds can fail HTTPS validation for image.tmdb.org,
+// so use HTTP on those devices.
+const _useHttp = isWebOS() || isLegacyTizen();
 
 export const setConfig = (url, user) => {
 jellyseerrUrl = url?.replace(/\/+$/, '');

--- a/packages/app/src/services/jellyseerrApi.js
+++ b/packages/app/src/services/jellyseerrApi.js
@@ -654,29 +654,6 @@ if (!path) return null;
 const proto = shouldUseHttp ? 'http' : 'https';
 const normalizedPath = String(path).trim();
 
-if (!normalizedPath) return null;
-
-// If backend already returns an absolute URL, keep it but normalize protocol
-// for TMDB hosts on legacy devices.
-if (/^https?:\/\//i.test(normalizedPath)) {
-try {
-const parsed = new URL(normalizedPath);
-const host = parsed.hostname.toLowerCase();
-if (host === 'image.tmdb.org' || host.endsWith('.themoviedb.org')) {
-parsed.protocol = `${proto}:`;
-return parsed.toString();
-}
-return normalizedPath;
-} catch (e) {
-void e;
-return normalizedPath;
-}
-}
-
-if (normalizedPath.startsWith('//')) {
-return `${proto}:${normalizedPath}`;
-}
-
 if (normalizedPath.startsWith('/t/p/')) {
 return `${proto}://image.tmdb.org${normalizedPath}`;
 }

--- a/packages/app/src/services/jellyseerrApi.js
+++ b/packages/app/src/services/jellyseerrApi.js
@@ -10,14 +10,14 @@ let jellyfinAccessToken = null;
 const isLegacyTizen = () => {
 if (!isTizen() || typeof navigator === 'undefined') return false;
 const match = (navigator.userAgent || '').match(/Tizen\s([0-9]+(?:\.[0-9]+)?)/i);
-if (!match) return false;
+if (!match) return true;
 const version = parseFloat(match[1]);
-return Number.isFinite(version) && version <= 2.4;
+return Number.isFinite(version) && version <= 3.0;
 };
 
-// webOS 4 and legacy Tizen builds can fail HTTPS validation for image.tmdb.org,
+// webOS 4 and legacy Tizen builds (<=3.0) can fail HTTPS validation for image.tmdb.org,
 // so use HTTP on those devices.
-const _useHttp = isWebOS() || isLegacyTizen();
+const shouldUseHttp = () => isWebOS() || isLegacyTizen();
 
 export const setConfig = (url, user) => {
 jellyseerrUrl = url?.replace(/\/+$/, '');
@@ -658,8 +658,38 @@ return getTv(tmdbId);
 
 export const getImageUrl = (path, size = 'w500') => {
 if (!path) return null;
-const proto = _useHttp ? 'http' : 'https';
-return `${proto}://image.tmdb.org/t/p/${size}${path}`;
+const proto = shouldUseHttp() ? 'http' : 'https';
+const normalizedPath = String(path).trim();
+
+if (!normalizedPath) return null;
+
+// If backend already returns an absolute URL, keep it but normalize protocol
+// for TMDB hosts on legacy devices.
+if (/^https?:\/\//i.test(normalizedPath)) {
+try {
+const parsed = new URL(normalizedPath);
+const host = parsed.hostname.toLowerCase();
+if (host === 'image.tmdb.org' || host.endsWith('.themoviedb.org')) {
+parsed.protocol = `${proto}:`;
+return parsed.toString();
+}
+return normalizedPath;
+} catch (e) {
+void e;
+return normalizedPath;
+}
+}
+
+if (normalizedPath.startsWith('//')) {
+return `${proto}:${normalizedPath}`;
+}
+
+if (normalizedPath.startsWith('/t/p/')) {
+return `${proto}://image.tmdb.org${normalizedPath}`;
+}
+
+const filePath = normalizedPath.startsWith('/') ? normalizedPath : `/${normalizedPath}`;
+return `${proto}://image.tmdb.org/t/p/${size}${filePath}`;
 };
 
 export const proxyImage = async (imageUrl) => {

--- a/packages/app/src/services/jellyseerrApi.js
+++ b/packages/app/src/services/jellyseerrApi.js
@@ -1,4 +1,4 @@
-import {isWebOS, isTizen} from '../platform';
+import {isWebOS, isLegacyTizen} from '../platform';
 
 let jellyseerrUrl = null;
 let userId = null;
@@ -7,13 +7,6 @@ let moonfinMode = false;
 let jellyfinServerUrl = null;
 let jellyfinAccessToken = null;
 
-const isLegacyTizen = () => {
-if (!isTizen() || typeof navigator === 'undefined') return false;
-const match = (navigator.userAgent || '').match(/Tizen\s([0-9]+(?:\.[0-9]+)?)/i);
-if (!match) return true;
-const version = parseFloat(match[1]);
-return Number.isFinite(version) && version <= 3.0;
-};
 
 // webOS 4 and legacy Tizen builds (<=3.0) can fail HTTPS validation for image.tmdb.org,
 // so use HTTP on those devices.

--- a/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
+++ b/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
@@ -674,9 +674,10 @@ const CancelRequestPopup = memo(({open, pendingRequests, title, onConfirm, onClo
 	);
 });
 
+const supportsExternalTrailerSearch = !isLegacyTizen();
+
 const JellyseerrDetails = ({mediaType, mediaId, onClose, onSelectItem, onPlayInMoonfin, onSelectPerson, onSelectKeyword, onBack, backHandlerRef}) => {
 	const {isAuthenticated, user: contextUser} = useJellyseerr();
-	const supportsExternalTrailerSearch = !isLegacyTizen();
 	const [details, setDetails] = useState(null);
 	const [loading, setLoading] = useState(true);
 	const [requesting, setRequesting] = useState(false);
@@ -994,13 +995,12 @@ const JellyseerrDetails = ({mediaType, mediaId, onClose, onSelectItem, onPlayInM
 	}, [pendingRequests, mediaId, mediaType]);
 
 	const handleTrailer = useCallback(() => {
-		if (!supportsExternalTrailerSearch) return;
 		const mediaTitle = details?.title || details?.name || 'Unknown';
 		const mediaYear = details?.releaseDate?.substring(0, 4) || details?.firstAirDate?.substring(0, 4) || '';
 		const searchQuery = `${mediaTitle} ${mediaYear} official trailer`;
 		const youtubeUrl = `https://www.youtube.com/results?search_query=${encodeURIComponent(searchQuery)}`;
 		window.open(youtubeUrl, '_blank');
-	}, [details, supportsExternalTrailerSearch]);
+	}, [details]);
 
 	const handlePlay = useCallback(() => {
 		const jellyfinMediaId = details?.mediaInfo?.jellyfinMediaId;

--- a/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
+++ b/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
@@ -7,19 +7,12 @@ import Popup from '@enact/sandstone/Popup';
 import Button from '@enact/sandstone/Button';
 import $L from '@enact/i18n/$L';
 import jellyseerrApi, {canRequestMovies, canRequestTv, canRequest4kMovies, canRequest4kTv, hasAdvancedRequestPermission} from '../../services/jellyseerrApi';
-import {isTizen} from '../../platform';
+import {isLegacyTizen} from '../../platform';
 import {useJellyseerr} from '../../context/JellyseerrContext';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import {KEYS} from '../../utils/keys';
 import css from './JellyseerrDetails.module.less';
 
-const isLegacyTizen = () => {
-	if (!isTizen() || typeof navigator === 'undefined') return false;
-	const match = (navigator.userAgent || '').match(/Tizen\s([0-9]+(?:\.[0-9]+)?)/i);
-	if (!match) return true;
-	const version = parseFloat(match[1]);
-	return !Number.isFinite(version) || version <= 3.0;
-};
 
 const safeFocus = (spotlightId) => {
 	try {

--- a/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
+++ b/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
@@ -7,10 +7,19 @@ import Popup from '@enact/sandstone/Popup';
 import Button from '@enact/sandstone/Button';
 import $L from '@enact/i18n/$L';
 import jellyseerrApi, {canRequestMovies, canRequestTv, canRequest4kMovies, canRequest4kTv, hasAdvancedRequestPermission} from '../../services/jellyseerrApi';
+import {isTizen} from '../../platform';
 import {useJellyseerr} from '../../context/JellyseerrContext';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import {KEYS} from '../../utils/keys';
 import css from './JellyseerrDetails.module.less';
+
+const isLegacyTizen = () => {
+	if (!isTizen() || typeof navigator === 'undefined') return false;
+	const match = (navigator.userAgent || '').match(/Tizen\s([0-9]+(?:\.[0-9]+)?)/i);
+	if (!match) return true;
+	const version = parseFloat(match[1]);
+	return !Number.isFinite(version) || version <= 3.0;
+};
 
 const safeFocus = (spotlightId) => {
 	try {
@@ -674,6 +683,7 @@ const CancelRequestPopup = memo(({open, pendingRequests, title, onConfirm, onClo
 
 const JellyseerrDetails = ({mediaType, mediaId, onClose, onSelectItem, onPlayInMoonfin, onSelectPerson, onSelectKeyword, onBack, backHandlerRef}) => {
 	const {isAuthenticated, user: contextUser} = useJellyseerr();
+	const supportsExternalTrailerSearch = !isLegacyTizen();
 	const [details, setDetails] = useState(null);
 	const [loading, setLoading] = useState(true);
 	const [requesting, setRequesting] = useState(false);
@@ -991,12 +1001,13 @@ const JellyseerrDetails = ({mediaType, mediaId, onClose, onSelectItem, onPlayInM
 	}, [pendingRequests, mediaId, mediaType]);
 
 	const handleTrailer = useCallback(() => {
+		if (!supportsExternalTrailerSearch) return;
 		const mediaTitle = details?.title || details?.name || 'Unknown';
 		const mediaYear = details?.releaseDate?.substring(0, 4) || details?.firstAirDate?.substring(0, 4) || '';
 		const searchQuery = `${mediaTitle} ${mediaYear} official trailer`;
 		const youtubeUrl = `https://www.youtube.com/results?search_query=${encodeURIComponent(searchQuery)}`;
 		window.open(youtubeUrl, '_blank');
-	}, [details]);
+	}, [details, supportsExternalTrailerSearch]);
 
 	const handlePlay = useCallback(() => {
 		const jellyfinMediaId = details?.mediaInfo?.jellyfinMediaId;
@@ -1349,16 +1360,18 @@ const JellyseerrDetails = ({mediaType, mediaId, onClose, onSelectItem, onPlayInM
 							)}
 
 							{/* Watch Trailer Button */}
-							<div className={css.btnWrapper}>
-								<SpottableDiv className={css.btnAction} onClick={handleTrailer}>
-									<span className={css.btnIcon}>
-										<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">
-											<path d="M160-120v-720h80v80h80v-80h320v80h80v-80h80v720h-80v-80h-80v80H320v-80h-80v80h-80Zm80-160h80v-80h-80v80Zm0-160h80v-80h-80v80Zm0-160h80v-80h-80v80Zm400 320h80v-80h-80v80Zm0-160h80v-80h-80v80Zm0-160h80v-80h-80v80ZM400-200h160v-560H400v560Zm0-560h160-160Z"/>
-										</svg>
-									</span>
-								</SpottableDiv>
-								<span className={css.btnLabel}>{$L('Watch Trailer')}</span>
-							</div>
+							{supportsExternalTrailerSearch && (
+								<div className={css.btnWrapper}>
+									<SpottableDiv className={css.btnAction} onClick={handleTrailer}>
+										<span className={css.btnIcon}>
+											<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">
+												<path d="M160-120v-720h80v80h80v-80h320v80h80v-80h80v720h-80v-80h-80v80H320v-80h-80v80h-80Zm80-160h80v-80h-80v80Zm0-160h80v-80h-80v80Zm0-160h80v-80h-80v80Zm400 320h80v-80h-80v80Zm0-160h80v-80h-80v80Zm0-160h80v-80h-80v80ZM400-200h160v-560H400v560Zm0-560h160-160Z"/>
+											</svg>
+										</span>
+									</SpottableDiv>
+									<span className={css.btnLabel}>{$L('Watch Trailer')}</span>
+								</div>
+							)}
 
 							{/* Play in Moonfin Button (if available) */}
 							{isAvailable && (


### PR DESCRIPTION
# Pull Request

## Summary
This PR fixes Jellyseerr media loading on legacy Tizen devices, where metadata text is visible but posters/backdrops often fail to load.

The change is intentionally scoped to legacy behavior to minimize risk for newer platforms.

## Related Issues
- Closes #158
- Related to #158

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added legacy-scoped image URL normalization for Jellyseerr/TMDB image paths.
- Added legacy protocol fallback for image requests to improve reliability on older TLS/certificate environments.
- Disabled/hid external trailer action on legacy Tizen where this flow is not reliably usable.

## Platform
- [x] Tizen (Samsung)
- [ ] webOS (LG)
- [ ] Both / Shared code

## Testing
- [x] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Build the legacy Tizen package.
2. Install generated WGT on legacy Tizen emulator and launch app.
3. Open Jellyseerr sections with posters/backdrops (for example Discover/Trending/details).
4. Verify metadata appears and image rendering behavior is correct.

## Screenshots (if applicable)
N/A (compatibility fix, no intentional UI redesign).

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [ ] No new warnings introduced