### PR TITLE
Fix: Live TV not operational after watching regular media

### DIFF
--- a/packages/app/src/App/App.js
+++ b/packages/app/src/App/App.js
@@ -575,6 +575,8 @@ const AppContent = (props) => {
 	const handlePlayerEnd = useCallback(() => {
 		setIsPlayerPaused(false);
 		setPlayingItem(null);
+		setPlaybackOptions(null);
+		setIsResume(false);
 		handleBack();
 		window.dispatchEvent(new CustomEvent('moonfin:browseRefresh'));
 	}, [handleBack]);
@@ -634,6 +636,8 @@ const AppContent = (props) => {
 
 	const handlePlayChannel = useCallback((channel) => {
 		setPlayingItem(channel);
+		setPlaybackOptions(null);
+		setIsResume(false);
 		navigateTo(PANELS.PLAYER);
 	}, [navigateTo]);
 
@@ -643,6 +647,8 @@ const AppContent = (props) => {
 
 	const handlePlayRecording = useCallback((recording) => {
 		setPlayingItem(recording);
+		setPlaybackOptions(null);
+		setIsResume(false);
 		navigateTo(PANELS.PLAYER);
 	}, [navigateTo]);
 


### PR DESCRIPTION
# Pull Request

## Summary
This pull request makes a few small tweaks to how playback state is handled in the `AppContent` component. The goal is to make sure playback options and resume data don’t carry over between sessions.

Jellyfin was getting the previous played items `MediaSourceId` and other items in the request which caused an empty result as the Live TV do not use these properties.

## Type of Change
- [x] Bug fix

## Changes Made
- When playback finishes, handlePlayerEnd now clears out any existing playback options and resume state.
- Starting a new channel or recording (via handlePlayChannel and handlePlayRecording) also resets those values so each session begins clean.

## Platform
- [x] Both / Shared code

## Testing
- [x] Tested on physical device

### Test Steps
1. Play Live TV
2. Play Movie
3. Play Live TV - This step now works

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
