### PR TITLE
add wrap-around navigation for media rows

### DIFF
--- a/packages/app/src/components/MediaCard/MediaCard.js
+++ b/packages/app/src/components/MediaCard/MediaCard.js
@@ -10,7 +10,7 @@ const SpottableDiv = Spottable('div');
 const POSTER_SIZE_MULTIPLIERS = {small: 0.8, default: 1, large: 1.2, xlarge: 1.4};
 const BASE_SIZES = {portrait: [240, 360], landscape: [384, 216], square: [240, 240]};
 
-const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusItem, showServerBadge = false, showOverview = false, eagerLoad = false}) => {
+const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusItem, showServerBadge = false, showOverview = false, eagerLoad = false, spotlightId, onSpotlightLeft, onSpotlightRight}) => {
 	const {settings} = useSettings();
 	const isLandscape = cardType === 'landscape';
 	const isSquare = cardType === 'square' || (cardType === 'portrait' && (item.Type === 'MusicAlbum' || item.Type === 'MusicArtist' || item.Type === 'Audio'));
@@ -132,7 +132,7 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 	const imgSizeStyle = sizeMultiplier !== 1 ? {height: cardHeight + 'px'} : undefined;
 
 	return (
-		<SpottableDiv className={cardClass} onClick={handleClick} onFocus={handleFocus} style={sizeStyle}>
+		<SpottableDiv className={cardClass} onClick={handleClick} onFocus={handleFocus} style={sizeStyle} spotlightId={spotlightId} onSpotlightLeft={onSpotlightLeft} onSpotlightRight={onSpotlightRight}>
 			<div className={css.imageContainer}>
 				{imageUrl ? (
 					<img

--- a/packages/app/src/components/MediaRow/MediaRow.js
+++ b/packages/app/src/components/MediaRow/MediaRow.js
@@ -1,5 +1,6 @@
 import {useCallback, useRef, useEffect, memo} from 'react';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
+import Spotlight from '@enact/spotlight';
 import MediaCard from '../MediaCard';
 import {KEYS} from '../../utils/keys';
 
@@ -75,6 +76,18 @@ const MediaRow = ({
 		}
 	}, [rowIndex, onNavigateUp, onNavigateDown]);
 
+	const handleWrapLeft = useCallback((e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        Spotlight.focus(`media-${keyPrefix}-${items[items.length - 1].Id}`);
+    }, [items, keyPrefix]);
+
+    const handleWrapRight = useCallback((e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        Spotlight.focus(`media-${keyPrefix}-${items[0].Id}`);
+    }, [items, keyPrefix]);
+
 	if (!items || items.length === 0) return null;
 
 	return (
@@ -88,19 +101,28 @@ const MediaRow = ({
 			<h2 className={css.title}>{title}</h2>
 			<div className={css.scroller} ref={scrollerRef} onFocus={handleFocus}>
 				<div className={css.items}>
-					{items.map((item) => (
-						<MediaCard
-							key={`${keyPrefix}-${item.Id}`}
-							item={item}
-							serverUrl={serverUrl}
-							cardType={cardType}
-							onSelect={handleSelect}
-							onFocusItem={onFocusItem}
-							showServerBadge={showServerBadge}
-							showOverview={showOverview}
-							eagerLoad={rowIndex === 0}
-						/>
-					))}
+						{items.map((item, index) => {
+							const spotlightId = `media-${keyPrefix}-${item.Id}`;
+							const isFirst = index === 0;
+							const isLast = index === items.length - 1;
+
+							return (
+								<MediaCard
+									key={`${keyPrefix}-${item.Id}`}
+									item={item}
+									serverUrl={serverUrl}
+									cardType={cardType}
+									onSelect={handleSelect}
+									onFocusItem={onFocusItem}
+									showServerBadge={showServerBadge}
+									showOverview={showOverview}
+									eagerLoad={rowIndex === 0}
+									spotlightId={spotlightId}
+									onSpotlightLeft={isFirst ? handleWrapLeft : null}
+									onSpotlightRight={isLast ? handleWrapRight : null}
+								/>
+							);
+						})}
 				</div>
 			</div>
 		</RowContainer>

--- a/packages/app/src/components/MediaRow/MediaRow.js
+++ b/packages/app/src/components/MediaRow/MediaRow.js
@@ -82,17 +82,19 @@ const MediaRow = ({
 		e.preventDefault();
 		e.stopPropagation();
 		if (settings.navbarPosition === 'left') {
-			Spotlight.focus('navbar');
+			if (!Spotlight.focus('navbar')) {
+				Spotlight.move('left');
+			}
 		} else {
 			Spotlight.focus(`media-${keyPrefix}-${items[items.length - 1].Id}`);
 		}
 	}, [items, keyPrefix, settings.navbarPosition]);
 
-    const handleWrapRight = useCallback((e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        Spotlight.focus(`media-${keyPrefix}-${items[0].Id}`);
-    }, [items, keyPrefix]);
+	const handleWrapRight = useCallback((e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		Spotlight.focus(`media-${keyPrefix}-${items[0].Id}`);
+	}, [items, keyPrefix]);
 
 	if (!items || items.length === 0) return null;
 

--- a/packages/app/src/components/MediaRow/MediaRow.js
+++ b/packages/app/src/components/MediaRow/MediaRow.js
@@ -3,6 +3,7 @@ import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDeco
 import Spotlight from '@enact/spotlight';
 import MediaCard from '../MediaCard';
 import {KEYS} from '../../utils/keys';
+import {useSettings} from '../../context/SettingsContext';
 
 import css from './MediaRow.module.less';
 
@@ -27,6 +28,7 @@ const MediaRow = ({
 	className,
 	registerRowRef
 }) => {
+	const {settings} = useSettings();
 	const scrollerRef = useRef(null);
 	const scrollTimeoutRef = useRef(null);
 	const rowElementRef = useRef(null);
@@ -77,10 +79,14 @@ const MediaRow = ({
 	}, [rowIndex, onNavigateUp, onNavigateDown]);
 
 	const handleWrapLeft = useCallback((e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        Spotlight.focus(`media-${keyPrefix}-${items[items.length - 1].Id}`);
-    }, [items, keyPrefix]);
+		e.preventDefault();
+		e.stopPropagation();
+		if (settings.navbarPosition === 'left') {
+			Spotlight.focus('navbar');
+		} else {
+			Spotlight.focus(`media-${keyPrefix}-${items[items.length - 1].Id}`);
+		}
+	}, [items, keyPrefix, settings.navbarPosition]);
 
     const handleWrapRight = useCallback((e) => {
         e.preventDefault();


### PR DESCRIPTION
# Pull Request

## Summary
Add wrap-around navigation for media rows so users can jump from the leftmost item to the rightmost item, and vice versa, instead of pressing the remote repeatedly.

## Related Issues

- Related to #176 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added "wrap-around focus" behavior on media rows.
- Kept navigation consistent with the current navbar position.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [x] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a media row.
2. Move focus to the first item and press left.
3. Move focus to the last item and press right.


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced