### PR TITLE
fix: scope focus scale to inner wrapper to avoid layout reflow

### DIFF
--- a/packages/app/src/views/Favorites/Favorites.js
+++ b/packages/app/src/views/Favorites/Favorites.js
@@ -345,6 +345,7 @@ className={css.itemCard}
 onClick={handleItemClick}
 data-index={index}
 >
+<div className={css.itemCardInner}>
 {imageUrl ? (
 <img
 className={`${css.poster} ${isPerson ? css.personPoster : ''}`}
@@ -371,6 +372,7 @@ loading="lazy"
 <svg viewBox="0 0 24 24"><path fill="white" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>
 </div>
 )}
+</div>
 </SpottableDiv>
 );
 }, [serverUrl, handleItemClick, items.length, totalCount, isLoading, loadItems, imageType, posterHeight, unifiedMode]);

--- a/packages/app/src/views/Favorites/Favorites.module.less
+++ b/packages/app/src/views/Favorites/Favorites.module.less
@@ -156,7 +156,6 @@ height: 0;
 .itemCard {
 position: relative;
 cursor: pointer;
-transition: all 0.2s ease;
 border-radius: 8px;
 overflow: visible;
 background: transparent;
@@ -164,13 +163,23 @@ margin: 10px;
 
 &:focus {
 outline: none;
-transform: scale(1.05);
 z-index: 10;
+
+.itemCardInner {
+transform: scale(1.05);
+}
 
 .poster {
 border-color: white;
 }
 }
+}
+
+.itemCardInner {
+position: relative;
+width: 100%;
+height: 100%;
+transition: transform 0.2s ease;
 }
 
 .poster {

--- a/packages/app/src/views/Library/Library.js
+++ b/packages/app/src/views/Library/Library.js
@@ -740,6 +740,7 @@ onFocus={() => {
 }}
 data-index={index}
 >
+<div className={css.itemCardInner}>
 {imageUrl ? (
 <img
 className={css.poster}
@@ -777,6 +778,7 @@ loading="lazy"
 <svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" /></svg>
 </div>
 )}
+</div>
 </SpottableDiv>
 );
 }, [effectiveServerUrl, handleItemClick, items.length, totalCount, isLoading, loadItems, effectiveImageType, posterHeight, isSquareImage, isFolderView, settings]);

--- a/packages/app/src/views/Library/Library.module.less
+++ b/packages/app/src/views/Library/Library.module.less
@@ -320,7 +320,6 @@
 .itemCard {
 	position: relative;
 	cursor: pointer;
-	transition: transform 0.2s ease;
 	border-radius: 8px;
 	overflow: visible;
 	background: transparent;
@@ -328,13 +327,23 @@
 
 	&:focus {
 		outline: none;
-		transform: scale(1.05);
 		z-index: 10;
+
+		.itemCardInner {
+			transform: scale(1.05);
+		}
 
 		.poster {
 			border-color: white;
 		}
 	}
+}
+
+.itemCardInner {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	transition: transform 0.2s ease;
 }
 
 .poster {


### PR DESCRIPTION

[MrSimmo-FIX-CHANGES.md](https://github.com/user-attachments/files/27485446/MrSimmo-FIX-CHANGES.md)
Replace 'transition: all' on .itemCard with 'transition: transform' on a new .itemCardInner element. Eliminates CPU reflow during focus animations on lower-power Smart TV hardware. Applied symmetrically to Favorites and Library views.

# Pull Request

## Summary
I've attempted to fix the issue I reported in [https://github.com/Moonfin-Client/Smart-TV/issues/111#issuecomment-4270176875](url). I used Claude Code so please do verify before merging. If it's possible to share a test version for the people reporting the same before the merge, it would be useful - keen not to introduce other issues.

I have also included a markdown with the changes proposed, in the PR.

## Related Issues
[https://github.com/Moonfin-Client/Smart-TV/issues/111#issuecomment-4270176875](url)

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- UI scrolling changes to Library and Favourites views. 
- 
- 

## Platform
- [x ] Tizen (Samsung)
- [ ] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [x ] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [x ] Not tested (explain why): Virtual testing on local dev, not tested on TV as yet.

### Test Steps
1. Push updated package to Samsung Tizen 5
2. Open package
3. Check UI scrolling

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [ ] Code builds successfully
- [ ] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
