### PR TITLE
fix intro/outro settings

### DIFF
--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -29,8 +29,6 @@ const defaultSettings = {
 	subtitleShadowBlur: 0.1,
 	subtitlePositionAbsolute: 90,
 	seekStep: 10,
-	skipIntro: true,
-	skipCredits: false,
 	autoPlay: true,
 	theme: 'dark',
 	homeRows: DEFAULT_HOME_ROWS,

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -906,7 +906,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			pendingSeekMsRef.current = null;
 		};
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [item, resume, selectedQuality, settings.maxBitrate, settings.preferTranscode, settings.forceDirectPlay, settings.subtitleMode, settings.skipIntro, applyDisplayWindow]);
+	}, [item, resume, selectedQuality, settings.maxBitrate, settings.preferTranscode, settings.forceDirectPlay, settings.subtitleMode, settings.introAction, settings.outroAction, applyDisplayWindow]);
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return () => {};

--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -566,7 +566,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			maxBitrate: settings.maxBitrate,
 			preferTranscode: settings.preferTranscode,
 			subtitleMode: settings.subtitleMode,
-			skipIntro: settings.skipIntro,
+			skipIntro: settings.introAction,
 			initialAudioIndex,
 			initialSubtitleIndex
 		});
@@ -859,7 +859,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			}
 		};
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [item, resume, selectedQuality, settings.maxBitrate, settings.preferTranscode, settings.forceDirectPlay, settings.subtitleMode, settings.skipIntro, initialAudioIndex, initialSubtitleIndex]);
+	}, [item, resume, selectedQuality, settings.maxBitrate, settings.preferTranscode, settings.forceDirectPlay, settings.subtitleMode, settings.introAction, settings.outroAction, initialAudioIndex, initialSubtitleIndex]);
 
 	useEffect(() => {
 		if (mediaUrl) {


### PR DESCRIPTION
# Pull Request

## Summary
older skipIntro wasn't replaced everywhere and therefore migrated again and again...

## Related Issues
- Fixes #205 & #198

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- old skipIntro replaced with introAction/outroAction 
- removed default skipIntro value

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Set intro/outro Action in settings to something else
2. Reopen Moonfin app
3. State should now persist and the choosen action is working as expected

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
