### PR TITLE
screensaver during paused state works again

### DIFF
--- a/packages/app/src/App/App.js
+++ b/packages/app/src/App/App.js
@@ -137,13 +137,12 @@ const AppContent = (props) => {
 		settings.screensaverEnabled &&
 		isAuthenticated &&
 		panelIndex !== PANELS.LOGIN &&
-		panelIndex !== PANELS.PLAYER &&
+		(panelIndex !== PANELS.PLAYER || isPlayerPaused) &&
 		!showExitDialog &&
 		!showSettingsPanel &&
 		!showAccountModal &&
 		!photoViewerItem &&
-		!comicViewerItem &&
-		!isPlayerPaused
+		!comicViewerItem
 	);
 	const {isInactive: showScreensaver, dismiss: dismissScreensaver} = useInactivityTimer(screensaverTimeout, screensaverEnabled);
 


### PR DESCRIPTION
# Pull Request

## Summary
Give us the screensaver back :)

## Related Issues
Link related issues or tickets separated by commas.

- Closes #207
- Fixes #207
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- changed the screensaver conditions so it will be available in paused state

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. pause movie/episode
2. Screensaver pops up after the specified amount of time
3. user happy 

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
