### PR TITLE
Fix MKV dolby vision webOS < 25 and fix seek when not in direct play

### DIFF
--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -1018,21 +1018,7 @@ export const updateCurrentSession = (updates) => {
 
 export const isDirectPlay = () => currentSession?.playMethod === PlayMethod.DirectPlay;
 
-/**
- * Rewrite the StartTimeTicks parameter in an existing HLS transcode URL.
- * This allows seeking within the same transcode session without tearing down
- * the player pipeline or creating a new PlaySessionId.
- */
-export const rewriteTranscodeSeekUrl = (url, newStartTicks) => {
-	if (!url) return url;
-	// Replace existing StartTimeTicks value
-	if (url.includes('StartTimeTicks=')) {
-		return url.replace(/StartTimeTicks=\d+/, 'StartTimeTicks=' + Math.floor(newStartTicks));
-	}
-	// Append if not present
-	const separator = url.includes('?') ? '&' : '?';
-	return url + separator + 'StartTimeTicks=' + Math.floor(newStartTicks);
-};
+
 
 export const getPlaybackUrl = async (itemId, startPositionTicks = 0, options = {}) => {
 	return getPlaybackInfo(itemId, {...options, startPositionTicks});
@@ -1045,7 +1031,6 @@ export default {
 	getPlaybackInfo,
 	getPlaybackInfoWithFallback,
 	getPlaybackUrl,
-	rewriteTranscodeSeekUrl,
 	getSubtitleUrl,
 	fetchItemChapters,
 	getChapterImageUrl,

--- a/packages/app/src/views/Details/Details.js
+++ b/packages/app/src/views/Details/Details.js
@@ -64,7 +64,7 @@ const getMediaBadges = (item, versionIndex = 0) => {
 
 		// HDR/DV badges
 		const rangeType = video.VideoRangeType;
-		if (rangeType === 'DOVIWithHDR10' || rangeType === 'DOVI') {
+		if (rangeType === 'DOVIWithHDR10' || rangeType === 'DOVI' || rangeType === 'DOVIWithHDR10Plus') {
 			badges.push({type: 'badgeDv', label: 'DV'});
 		}
 		if (rangeType && rangeType !== 'SDR') {

--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -160,8 +160,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 	const prevItemIdRef = useRef(null);
 	const hlsPlayerRef = useRef(null);
 	const pendingAudioRef = useRef(null);
-	const transcodeOffsetTicksRef = useRef(0);
-	const transcodeOffsetDetectedRef = useRef(true);
+
 	const playbackStartTimeoutRef = useRef(null);
 	const pendingResumeTicksRef = useRef(0);
 	const hasReportedStartRef = useRef(false);
@@ -632,20 +631,13 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				seekingTranscodeRef.current = false;
 
 				// Defer seek until pipeline is running
-				if (!isLiveTV && result.playMethod !== 'Transcode' && startPosition > 0) {
+				if (!isLiveTV && startPosition > 0) {
 					pendingResumeTicksRef.current = startPosition;
 					console.log('[Player] Pending resume seek:', startPosition, 'ticks (' + (startPosition / 10000000) + 's)');
 				} else {
 					pendingResumeTicksRef.current = 0;
 				}
 
-				if (!isLiveTV && result.playMethod === 'Transcode' && startPosition > 0) {
-					transcodeOffsetTicksRef.current = startPosition;
-					transcodeOffsetDetectedRef.current = false;
-				} else {
-					transcodeOffsetTicksRef.current = 0;
-					transcodeOffsetDetectedRef.current = true;
-				}
 
 				runTimeRef.current = result.runTimeTicks || 0;
 				setDuration((result.runTimeTicks || 0) / 10000000);
@@ -822,7 +814,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			}
 
 			const videoTime = videoElement ? videoElement.currentTime : 0;
-			const videoTicks = Math.floor(videoTime * 10000000) + transcodeOffsetTicksRef.current;
+			const videoTicks = Math.floor(videoTime * 10000000);
 			const currentPos = videoTicks > 0 ? videoTicks : positionRef.current;
 
 			const intendedStart = positionRef.current;
@@ -867,61 +859,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 		}
 	}, [mediaUrl]);
 
-	const seekInTranscode = useCallback(async (seekPositionTicks) => {
-		if (seekingTranscodeRef.current) return;
-		seekingTranscodeRef.current = true;
 
-		if (seekDebounceTimerRef.current) {
-			clearTimeout(seekDebounceTimerRef.current);
-			seekDebounceTimerRef.current = null;
-		}
-
-		console.log('[Player] seekInTranscode: seeking to', seekPositionTicks, 'ticks (', seekPositionTicks / 10000000, 's)');
-
-		sourceTransitionRef.current = true;
-
-		try {
-			const video = videoRef.current;
-			const currentUrl = mediaUrlRef.current;
-			const newUrl = playback.rewriteTranscodeSeekUrl(currentUrl, seekPositionTicks);
-
-			if (!newUrl || newUrl === currentUrl) {
-				console.warn('[Player] seekInTranscode: URL unchanged, skipping seek');
-				seekingTranscodeRef.current = false;
-				sourceTransitionRef.current = false;
-				return;
-			}
-
-			positionRef.current = seekPositionTicks;
-			lastSeekTargetRef.current = seekPositionTicks;
-			transcodeOffsetTicksRef.current = seekPositionTicks;
-			transcodeOffsetDetectedRef.current = false;
-
-			if (hlsPlayerRef.current) {
-				hlsPlayerRef.current.stopLoad();
-				hlsPlayerRef.current.loadSource(newUrl);
-			} else if (video) {
-				video.src = newUrl;
-				if (mimeType) video.type = mimeType;
-				video.load();
-				const p = video.play();
-				if (p && typeof p.catch === 'function') {
-					p.catch(e => {
-						if (e.name !== 'AbortError') {
-							console.error('[Player] seekInTranscode play() rejected:', e);
-						}
-					});
-				}
-			}
-
-			mediaUrlRef.current = newUrl;
-		} catch (err) {
-			console.error('[Player] seekInTranscode failed:', err);
-			setError($L('Failed to seek - please try again'));
-			sourceTransitionRef.current = false;
-			seekingTranscodeRef.current = false;
-		}
-	}, [mimeType]);
 
 	const seekByOffset = useCallback((deltaSec, updateSeekPosition) => {
 		const baseTime = (playMethod === 'Transcode')
@@ -934,10 +872,15 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 		positionRef.current = newTicks;
 		lastSeekTargetRef.current = newTicks;
 		if (playMethod === 'Transcode') {
-			setCurrentTime(newTime);
 			if (seekDebounceTimerRef.current) clearTimeout(seekDebounceTimerRef.current);
 			seekDebounceTimerRef.current = setTimeout(() => {
-				seekInTranscode(lastSeekTargetRef.current);
+				lastSeekTimeRef.current = Date.now();
+				if (healthMonitorRef.current) healthMonitorRef.current.reset();
+				try {
+					videoRef.current.currentTime = newTime;
+				} catch (e) {
+					console.warn('[Player] seekByOffset: failed to set currentTime:', e);
+				}
 			}, 600);
 		} else if (videoRef.current) {
 			lastSeekTimeRef.current = Date.now();
@@ -948,17 +891,22 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				console.warn('[Player] seekByOffset: failed to set currentTime:', e);
 			}
 		}
-	}, [duration, playMethod, seekInTranscode]);
+	}, [duration, playMethod]);
 
 	const seekToTicks = useCallback((ticks) => {
-		if (!videoRef.current) return;
 		const maxTicks = Math.max(0, runTimeRef.current - 10000000); // 1s before end
 		const clampedTicks = Math.max(0, Math.min(ticks, maxTicks));
 		positionRef.current = clampedTicks;
-		lastSeekTargetRef.current = clampedTicks;
+		lastSeekTargetRef.current = null;
 		if (playMethod === 'Transcode') {
-			seekInTranscode(clampedTicks);
-		} else {
+			lastSeekTimeRef.current = Date.now();
+			if (healthMonitorRef.current) healthMonitorRef.current.reset();
+			try {
+				videoRef.current.currentTime = clampedTicks;
+			} catch (e) {
+				console.warn('[Player] seekToTicks: failed to set currentTime:', e);
+			}
+		} else if (videoRef.current) {
 			lastSeekTimeRef.current = Date.now();
 			if (healthMonitorRef.current) healthMonitorRef.current.reset();
 			try {
@@ -967,7 +915,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				console.warn('[Player] seekToTicks: failed to set currentTime:', e);
 			}
 		}
-	}, [playMethod, seekInTranscode]);
+	}, [playMethod]);
 
 	useEffect(() => {
 		const video = videoRef.current;
@@ -988,7 +936,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 			let srcUrl = mediaUrl;
 			const resumeTicks = pendingResumeTicksRef.current;
-			if (resumeTicks > 0 && playMethod !== 'Transcode') {
+			if (resumeTicks > 0) {
 				const resumeSec = resumeTicks / 10000000;
 				srcUrl = mediaUrl + '#t=' + resumeSec;
 				console.log('[Player] Appending media fragment #t=' + resumeSec + ' for resume (' + resumeTicks + ' ticks)');
@@ -1322,9 +1270,8 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				setDecodedAspectRatio(width / height);
 			}
 
-			if (playMethod !== 'Transcode') {
-				setDuration(videoRef.current.duration);
-			}
+			setDuration(videoRef.current.duration);
+
 			const p = videoRef.current.play();
 			if (p && typeof p.catch === 'function') {
 				p.catch(err => {
@@ -1340,7 +1287,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				console.error('[Player] Deferred ASS init failed', err);
 			});
 		}
-	}, [playMethod, initAssRendererForStream]);
+	}, [initAssRendererForStream]);
 
 	const handlePlay = useCallback(() => {
 		setIsPaused(false);
@@ -1368,27 +1315,9 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 		if (videoRef.current) {
 			const rawTime = videoRef.current.currentTime;
 
-			if (playMethod === 'Transcode' && !transcodeOffsetDetectedRef.current && transcodeOffsetTicksRef.current > 0) {
-				if (rawTime > 1) {
-					transcodeOffsetDetectedRef.current = true;
-					console.log('[Player] Transcode seek offset: applying', transcodeOffsetTicksRef.current / 10000000, 's (raw:', rawTime, 's)');
 
-					const pendingTicks = lastSeekTargetRef.current;
-					sourceTransitionRef.current = false;
-					seekingTranscodeRef.current = false;
 
-					if (pendingTicks !== null && pendingTicks !== transcodeOffsetTicksRef.current) {
-						console.log('[Player] seekInTranscode: target changed during load, re-seeking to', pendingTicks / 10000000, 's');
-						setTimeout(() => seekInTranscode(pendingTicks), 100);
-					}
-				} else {
-					positionRef.current = transcodeOffsetTicksRef.current;
-					setCurrentTime(transcodeOffsetTicksRef.current / 10000000);
-					return;
-				}
-			}
-
-			const time = rawTime + transcodeOffsetTicksRef.current / 10000000;
+			const time = rawTime;
 			setCurrentTime(time);
 			const ticks = Math.floor(time * 10000000);
 			positionRef.current = ticks;
@@ -1411,7 +1340,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 			checkSegments(ticks);
 		}
-	}, [playMethod, checkSegments, subtitleTrackEvents, subtitleOffset, seekInTranscode]);
+	}, [checkSegments, subtitleTrackEvents, subtitleOffset]);
 
 	const handleWaiting = useCallback(() => {
 		setIsBuffering(true);
@@ -1634,7 +1563,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 	const handleBack = useCallback(async () => {
 		cancelNextEpisodeCountdown();
 		const currentPos = videoRef.current
-			? Math.floor(videoRef.current.currentTime * 10000000) + transcodeOffsetTicksRef.current
+			? Math.floor(videoRef.current.currentTime * 10000000)
 			: positionRef.current;
 		await playback.reportStop(currentPos);
 
@@ -1892,13 +1821,10 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				positionRef.current = currentPositionTicks;
 
 				// Preserve playback position when reloading for audio switch
-				if (result.playMethod !== playback.PlayMethod.Transcode && currentPositionTicks > 0) {
+				if (currentPositionTicks > 0) {
 					pendingResumeTicksRef.current = currentPositionTicks;
 				}
-				if (result.playMethod === playback.PlayMethod.Transcode) {
-					transcodeOffsetTicksRef.current = currentPositionTicks;
-					transcodeOffsetDetectedRef.current = false;
-				}
+
 
 				let newUrl = result.url;
 				if (result.playMethod === playback.PlayMethod.DirectPlay) {

--- a/packages/app/src/views/Settings/Settings.js
+++ b/packages/app/src/views/Settings/Settings.js
@@ -1029,7 +1029,7 @@ const Settings = ({ onBack, onLibrariesChanged, panelMode }) => {
 			{renderInfoItem(
 				'containers',
 				$L('Containers'),
-				['MP4', capabilities?.mkv && 'MKV', 'TS', capabilities?.webm && 'WebM', capabilities?.asf && 'ASF']
+				['MP4', capabilities?.mkv && 'MKV', 'TS', capabilities?.webm && 'WebM', capabilities?.asf && 'ASF', capabilities?.nativeHls && 'HLS', capabilities?.nativeHlsFmp4 && 'HLS-fMP4']
 					.filter(Boolean)
 					.join(', '),
 				'folder'

--- a/packages/platform-webos/src/deviceProfile.js
+++ b/packages/platform-webos/src/deviceProfile.js
@@ -339,8 +339,9 @@ const buildDirectPlayProfiles = (caps) => {
 	if (caps.mkv) {
 		// MKV supports broader video codecs per LG docs: MPEG-2, MPEG-4, H.264, VP8, VP9, HEVC, AV1
 		const mkvVideoCodecs = ['h264', 'mpeg4', 'mpeg2video', 'vp8'];
-		if (caps.hevc) mkvVideoCodecs.push('hevc', 'dvh1');
-		if (caps.dolbyVision) mkvVideoCodecs.push('dvhe');
+		if (caps.hevc) mkvVideoCodecs.push('hevc');
+		if (caps.webosVersion >= 25 && caps.hevc) mkvVideoCodecs.push('dvh1');
+		if (caps.webosVersion >= 25 && caps.dolbyVision) mkvVideoCodecs.push('dvhe');
 		if (caps.vp9) mkvVideoCodecs.push('vp9');
 		if (caps.av1) mkvVideoCodecs.push('av1');
 

--- a/packages/platform-webos/src/video.js
+++ b/packages/platform-webos/src/video.js
@@ -182,15 +182,17 @@ export const getPlayMethod = (mediaSource, capabilities, options = {}) => {
 	const videoOk = !videoCodec || supportedVideoCodecs.includes(videoCodec);
 	const audioOk = hasCompatibleAudio;
 	// Container can be comma-separated (e.g., "mov,mp4,m4a,3gp,3g2,mj2") - check if ANY match
-	const containerOk = !container || containerParts.some(c => supportedContainers.includes(c));
+	let containerOk = !container || containerParts.some(c => supportedContainers.includes(c));
 
 	// HDR compatibility check
 	let hdrOk = true;
+	let isDolbyVision = false;
 	if (videoStream?.VideoRangeType) {
 		const rangeType = videoStream.VideoRangeType.toUpperCase();
 		if (rangeType === 'DOVI') {
 			// Pure DV with no fallback layer needs native DV support
 			hdrOk = capabilities.dolbyVision;
+			isDolbyVision = true;
 			if (!hdrOk) console.log('[webosVideo] Pure Dolby Vision not supported (no fallback layer)');
 		} else if (rangeType.includes('DOVIWITH')) {
 			// DV with fallback layer - check if we can play the fallback
@@ -209,10 +211,12 @@ export const getPlayMethod = (mediaSource, capabilities, options = {}) => {
 				hdrOk = false;
 				console.log('[webosVideo] DV fallback layer not supported:', rangeType);
 			}
+			isDolbyVision = true;
 		} else if (rangeType.includes('DOLBY') || rangeType.includes('DV')) {
 			// Generic DV/DOLBY reference, needs native DV
 			hdrOk = capabilities.dolbyVision;
 			if (!hdrOk) console.log('[webosVideo] Dolby Vision not supported');
+			isDolbyVision = true;
 		} else if (rangeType.includes('HDR10+') || rangeType === 'HDR10PLUS') {
 			hdrOk = capabilities.hdr10Plus || capabilities.hdr10;
 			if (!hdrOk) console.log('[webosVideo] HDR10+ not supported');
@@ -222,6 +226,15 @@ export const getPlayMethod = (mediaSource, capabilities, options = {}) => {
 		} else if (rangeType.includes('HLG')) {
 			hdrOk = capabilities.hlg || capabilities.hdr10;
 			if (!hdrOk) console.log('[webosVideo] HLG not supported');
+		}
+	}
+
+	if(hdrOk && isDolbyVision){
+		if(container.includes("mkv") || container.includes("matroska")){
+			//on webOS < 25, dolby vision isn't supported on mkv
+			if(capabilities.webosVersion<25){
+				containerOk = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
WebOS < 25 does not support dolby vision content on MKV container, ask for remuxing if dolby vision content with mkv container is requested (note: remuxing, not transcoding, the content is unchanged!). 
This fixes #167 . However, there is another problem to fix, at least on my LG C1 (this problem was already present prior to this PR): When the content is being remuxed, the video restarts from the beginning and seeking does not work.

# Pull Request

## Summary
Provide a brief description of what this PR changes and why.

## Related Issues
Link related issues or tickets separated by commas.

- Fixes #167

## Type of Change
- [ X ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- 
- 
- 

## Platform
- [ ] Tizen (Samsung)
- [ X ] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [ X ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start Dolby vision content with mkv container on WebOS < 25
2. Now Dolby vision works and doesn't fallback to HDR anymore

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [ X ] Code builds successfully
- [ X ] Code follows project style and conventions
- [ X ] No unnecessary commented-out code
- [ X ] No new warnings introduced
 