### PR TITLE
Fix chapters on webOS and enable opus audio for webOS >= 6 & minor truehd refactor

### DIFF
--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -644,7 +644,16 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 				setAudioStreams(result.audioStreams || []);
 				setSubtitleStreams(result.subtitleStreams || []);
-				setChapters(result.chapters || []);
+
+				// Chapters are an Item property, not MediaSource - result.chapters may be empty
+				let chapterList = [];
+					if (!isLiveTV) {
+						chapterList = result.chapters || [];
+						if (chapterList.length === 0) {
+							chapterList = await playback.fetchItemChapters(item.Id, item);
+						}
+					}
+				setChapters(chapterList);
 
 				const defaultAudio = result.audioStreams?.find(s => s.isDefault);
 				if (initialAudioIndex !== undefined && initialAudioIndex !== null) {
@@ -902,7 +911,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			lastSeekTimeRef.current = Date.now();
 			if (healthMonitorRef.current) healthMonitorRef.current.reset();
 			try {
-				videoRef.current.currentTime = clampedTicks;
+				videoRef.current.currentTime = clampedTicks / 10000000;
 			} catch (e) {
 				console.warn('[Player] seekToTicks: failed to set currentTime:', e);
 			}
@@ -1883,7 +1892,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 		const percent = (e.clientX - rect.left) / rect.width;
 		const newTime = percent * duration;
 		const newTicks = Math.floor(newTime * 10000000);
-		seekToTicks(newTicks);
+		if(newTicks)seekToTicks(newTicks);
 	}, [duration, seekToTicks]);
 
 	const handleProgressKeyDown = useCallback((e) => {

--- a/packages/app/src/views/Settings/Settings.js
+++ b/packages/app/src/views/Settings/Settings.js
@@ -1020,7 +1020,9 @@ const Settings = ({ onBack, onLibrariesChanged, panelMode }) => {
 					capabilities?.ac3 && 'AC3',
 					capabilities?.eac3 && 'E-AC3',
 					capabilities?.dts && 'DTS',
-					capabilities?.dolbyAtmos && 'Atmos'
+					capabilities?.dtshd && 'DTS-HD',
+					capabilities?.dolbyAtmos && 'Atmos',
+					capabilities?.opus && 'OPUS'
 				]
 					.filter(Boolean)
 					.join(', '),

--- a/packages/platform-tizen/src/deviceProfile.js
+++ b/packages/platform-tizen/src/deviceProfile.js
@@ -367,6 +367,8 @@ export const getDeviceCapabilities = async () => {
 		ac3: testAc3Support(),
 		eac3: testEac3Support(),
 		truehd: testTruehdSupport(), // false - not in Samsung specs
+		dtshd: false,
+		opus: true,
 
 		// Video codec capabilities
 		hevc: testHevcSupport(),
@@ -411,9 +413,13 @@ export const getJellyfinDeviceProfile = async () => {
 	// FLAC: Listed in Samsung Music format table (media-specifications.html) as a supported codec
 	// ALAC: Also listed in Music table but omitted here (niche format, m4a container shared with AAC)
 	// NOT supported: DTS (explicitly stated), TrueHD (not documented)
-	const audioCodecs = ['aac', 'mp3', 'flac', 'opus', 'vorbis', 'pcm', 'wav'];
+	const audioCodecs = ['aac', 'mp3', 'flac','vorbis', 'pcm', 'wav'];
 	if (caps.ac3) audioCodecs.push('ac3');
 	if (caps.eac3) audioCodecs.push('eac3');
+	if (caps.opus) audioCodecs.push('opus');
+	if (caps.truehd) audioCodecs.push('truehd');
+	if (caps.dts) audioCodecs.push('dca', 'dts');
+	if (caps.dts && caps.dtshd) audioCodecs.push('dts-hd', 'dtshd');
 	// DTS intentionally excluded - Samsung docs: "DTS Audio codec is not supported"
 	// TrueHD intentionally excluded - not in Samsung specifications
 

--- a/packages/platform-tizen/src/video.js
+++ b/packages/platform-tizen/src/video.js
@@ -66,7 +66,10 @@ const getDefaultCapabilities = () => {
 		mkv: true,
 		nativeHls: true,
 		nativeHlsFmp4: true,
-		hlsAc3: true
+    dts: false,
+    dtshd: false,
+		hlsAc3: true,
+		opus: true
 	};
 };
 
@@ -115,9 +118,12 @@ export const getMediaCapabilities = async () => {
  * Get the list of audio codecs supported by the TV hardware.
  */
 export const getSupportedAudioCodecs = (capabilities) => {
-	const codecs = ['aac', 'mp3', 'flac', 'opus', 'vorbis', 'pcm', 'wav'];
+	const codecs = ['aac', 'mp3', 'flac', 'vorbis', 'pcm', 'wav'];
 	if (capabilities.ac3) codecs.push('ac3');
 	if (capabilities.eac3) codecs.push('eac3');
+	if (capabilities.opus) codecs.push('opus');
+	if (capabilities.dts) codecs.push('dts', 'dca');
+	if (capabilities.dts && capabilities.dtshd) codecs.push('dts-hd', 'dtshd');
 	// DTS: Samsung explicitly states not supported on any TV (2018-2025)
 	// TrueHD: Not documented in Samsung specifications
 	return codecs;

--- a/packages/platform-webos/src/deviceProfile.js
+++ b/packages/platform-webos/src/deviceProfile.js
@@ -224,6 +224,7 @@ export const getDeviceCapabilities = async () => {
 		// webOS can only passthrough TrueHD/DTS-HD to an AV receiver, not decode internally
 		truehd: false,
 		dtshd: false,
+		opus: webosVersion >= 6,
 
 		hevc: testHevcSupport(null, webosVersion),
 		av1: testAv1Support(null, webosVersion),
@@ -277,37 +278,92 @@ const buildVideoRangeTypes = (caps) => {
 	return rangeTypes.join('|');
 };
 
-const buildDirectPlayProfiles = (caps) => {
-	const profiles = [];
-
+const buildMp4VideoCodecs = (caps) => {
 	const mp4VideoCodecs = ['h264'];
 	if (caps.hevc) mp4VideoCodecs.push('hevc', 'dvh1');
 	if (caps.dolbyVision) mp4VideoCodecs.push('dvhe');
 	if (caps.av1) mp4VideoCodecs.push('av1');
+	return mp4VideoCodecs;
+}
 
-	// Per-container audio codecs based on LG's official AV format docs.
-	// Different containers support different audio codecs on webOS.
+const buildMp4AudioCodecs = (caps) => {
 	const dts = caps.dts || {}; // Per-container DTS support object
-
 	// MP4/M4V/MOV: ac3, eac3, aac, mp3; DTS only on webOS 23+ (model-specific)
 	const mp4AudioCodecs = ['aac', 'mp3'];
 	if (caps.ac3) mp4AudioCodecs.push('ac3');
 	if (caps.eac3) mp4AudioCodecs.push('eac3');
 	if (dts.mp4) mp4AudioCodecs.push('dca', 'dts');
+	if (dts.mp4 && caps.dtshd) mp4AudioCodecs.push('dts-hd', 'dtshd');
+	if (caps.opus) mp4AudioCodecs.push('opus');
+	if (caps.truehd) mp4AudioCodecs.push('truehd');
+	return mp4AudioCodecs;
 
+}
+
+const buildTsVideoCodecs = (caps) => {
+	// TS per LG docs: H.264, HEVC, MPEG-2; VC-1 is only documented in ASF/WMV
+	const tsVideoCodecs = ['h264'];
+	if (caps.hevc) tsVideoCodecs.push('hevc', 'dvh1');
+	if (caps.dolbyVision) tsVideoCodecs.push('dvhe');
+	tsVideoCodecs.push('mpeg2video');
+	return tsVideoCodecs;
+}
+
+const buildTsAudioCodecs = (caps) => {
+	const dts = caps.dts || {}; // Per-container DTS support object
+	// TS: ac3, eac3, aac, mp2, pcm, mp3; DTS only on webOS 23+ (model-specific)
+	const tsAudioCodecs = ['aac', 'mp2', 'mp3', 'pcm_s16le', 'pcm_s24le'];
+	if (caps.ac3) tsAudioCodecs.push('ac3');
+	if (caps.eac3) tsAudioCodecs.push('eac3');
+	if (dts.ts) tsAudioCodecs.push('dca', 'dts');
+	if (dts.ts && caps.dtshd) tsAudioCodecs.push('dts-hd', 'dtshd');
+	if (caps.opus) tsAudioCodecs.push('opus');
+	if (caps.truehd) tsAudioCodecs.push('truehd');
+	return tsAudioCodecs;
+}
+
+const buildMkvVideoCodecs = (caps) => {
+	// MKV supports broader video codecs per LG docs: MPEG-2, MPEG-4, H.264, VP8, VP9, HEVC, AV1
+	const mkvVideoCodecs = ['h264', 'mpeg4', 'mpeg2video', 'vp8'];
+	if (caps.hevc) mkvVideoCodecs.push('hevc');
+	if (caps.webosVersion >= 25 && caps.hevc) mkvVideoCodecs.push('dvh1');
+	if (caps.webosVersion >= 25 && caps.dolbyVision) mkvVideoCodecs.push('dvhe');
+	if (caps.vp9) mkvVideoCodecs.push('vp9');
+	if (caps.av1) mkvVideoCodecs.push('av1');
+	return mkvVideoCodecs
+}
+
+const buildMkvAudioCodecs = (caps) => {
+	const dts = caps.dts || {}; // Per-container DTS support object
+	// MP4/M4V/MOV: ac3, eac3, aac, mp3; DTS only on webOS 23+ (model-specific)
 	// MKV: ac3, eac3, aac, mp2, pcm, mp3, opus (24+), dts (all versions per LG docs)
 	// FLAC and Vorbis are NOT listed in MKV by LG docs (standalone formats only)
 	const mkvAudioCodecs = ['aac', 'mp2', 'mp3', 'pcm_s16le', 'pcm_s24le'];
 	if (caps.ac3) mkvAudioCodecs.push('ac3');
 	if (caps.eac3) mkvAudioCodecs.push('eac3');
 	if (dts.mkv) mkvAudioCodecs.push('dca', 'dts');
-	if (caps.webosVersion >= 24) mkvAudioCodecs.push('opus');
+	if (dts.mkv && caps.dtshd) mkvAudioCodecs.push('dts-hd', 'dtshd');
+	if (caps.opus) mkvAudioCodecs.push('opus');
+	if (caps.truehd) mkvAudioCodecs.push('truehd');
+	return mkvAudioCodecs;
 
-	// TS: ac3, eac3, aac, mp2, pcm, mp3; DTS only on webOS 23+ (model-specific)
-	const tsAudioCodecs = ['aac', 'mp2', 'mp3', 'pcm_s16le', 'pcm_s24le'];
-	if (caps.ac3) tsAudioCodecs.push('ac3');
-	if (caps.eac3) tsAudioCodecs.push('eac3');
-	if (dts.ts) tsAudioCodecs.push('dca', 'dts');
+}
+
+const buildDirectPlayProfiles = (caps) => {
+	const profiles = [];
+
+	const mp4VideoCodecs = buildMp4VideoCodecs(caps);
+
+	// Per-container audio codecs based on LG's official AV format docs.
+	// Different containers support different audio codecs on webOS.
+	const dts = caps.dts || {}; // Per-container DTS support object
+
+	const mp4AudioCodecs = buildMp4AudioCodecs(caps);
+
+	const mkvAudioCodecs = buildMkvAudioCodecs(caps);
+
+	const tsAudioCodecs =  buildTsAudioCodecs(caps);
+
 
 	// AVI: ac3, mp2, mp3, lpcm, adpcm; DTS only on webOS 4/4.5
 	const aviAudioCodecs = ['mp2', 'mp3', 'pcm_s16le', 'pcm_s24le'];
@@ -318,7 +374,10 @@ const buildDirectPlayProfiles = (caps) => {
 	if (caps.vp9) webmVideoCodecs.push('vp9');
 	if (caps.av1) webmVideoCodecs.push('av1');
 	const webmAudioCodecs = ['vorbis'];
-	if (caps.webosVersion >= 24) webmAudioCodecs.push('opus');
+	if (caps.opus) webmAudioCodecs.push('opus');
+
+	
+	
 
 	if (caps.webm) {
 		profiles.push({
@@ -337,13 +396,7 @@ const buildDirectPlayProfiles = (caps) => {
 	});
 
 	if (caps.mkv) {
-		// MKV supports broader video codecs per LG docs: MPEG-2, MPEG-4, H.264, VP8, VP9, HEVC, AV1
-		const mkvVideoCodecs = ['h264', 'mpeg4', 'mpeg2video', 'vp8'];
-		if (caps.hevc) mkvVideoCodecs.push('hevc');
-		if (caps.webosVersion >= 25 && caps.hevc) mkvVideoCodecs.push('dvh1');
-		if (caps.webosVersion >= 25 && caps.dolbyVision) mkvVideoCodecs.push('dvhe');
-		if (caps.vp9) mkvVideoCodecs.push('vp9');
-		if (caps.av1) mkvVideoCodecs.push('av1');
+		const mkvVideoCodecs = buildMkvVideoCodecs(caps);
 
 		profiles.push({
 			Container: 'mkv',
@@ -354,11 +407,8 @@ const buildDirectPlayProfiles = (caps) => {
 	}
 
 	if (caps.ts) {
-		// TS per LG docs: H.264, HEVC, MPEG-2; VC-1 is only documented in ASF/WMV
-		const tsVideoCodecs = ['h264'];
-		if (caps.hevc) tsVideoCodecs.push('hevc', 'dvh1');
-		if (caps.dolbyVision) tsVideoCodecs.push('dvhe');
-		tsVideoCodecs.push('mpeg2video');
+		
+		const tsVideoCodecs = buildTsVideoCodecs(caps);
 
 		profiles.push({
 			Container: 'ts,mpegts',
@@ -451,7 +501,7 @@ const buildDirectPlayProfiles = (caps) => {
 		});
 	});
 
-	if (caps.webosVersion >= 24) {
+	if (caps.opus) {
 		profiles.push({
 			Container: 'webm',
 			AudioCodec: 'opus',

--- a/packages/platform-webos/src/video.js
+++ b/packages/platform-webos/src/video.js
@@ -80,11 +80,12 @@ export const getSupportedAudioCodecs = (capabilities, container = '') => {
 		} else if (container === 'avi') {
 			dtsOk = !!dtsObj.avi;
 		}
-		if (dtsOk) codecs.push('dts', 'dca', 'dts-hd', 'dtshd');
+		if (dtsOk) codecs.push('dts', 'dca');
+		if (dtsOk && capabilities.dtshd) codecs.push('dts-hd', 'dtshd');
 	}
 
 	if (capabilities.truehd) codecs.push('truehd', 'mlp');
-	if (capabilities.webosVersion >= 24) codecs.push('opus');
+	if (capabilities.opus) codecs.push('opus');
 	codecs.push('vorbis', 'wma', 'amr', 'amrnb', 'amrwb');
 
 	return codecs;


### PR DESCRIPTION
# Pull Request

## Summary
Provide a brief description of what this PR changes and why.
Fixed chapters on webOS
enabled opus audio on weOS >= 6
truehd now managed through capabilities, meaning it could be forced by enabling the capability

## Related Issues
Link related issues or tickets separated by commas.

- Closes #211
- Fixes #211 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- 
- 
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
