### PR TITLE
Fixed focus and controls timeout

### DIFF
--- a/packages/app/src/views/Details/Details.js
+++ b/packages/app/src/views/Details/Details.js
@@ -178,6 +178,7 @@ const Details = ({itemId, initialItem, onPlay, onSelectItem, onSelectPerson, onI
 	// Refs
 	const pageScrollerRef = useRef(null);
 	const pageScrollToRef = useRef(null);
+	const lastFocusedElementRef = useRef(null);
 
 	// Data loading
 	useEffect(() => {
@@ -586,6 +587,7 @@ const Details = ({itemId, initialItem, onPlay, onSelectItem, onSelectPerson, onI
 	}, [trailerOverlay]);
 
 	const openModal = useCallback((modal) => {
+	  lastFocusedElementRef.current = document.activeElement;
 		setActiveModal(modal);
 		window.requestAnimationFrame(() => {
 			const modalId = `${modal}-modal`;
@@ -608,6 +610,11 @@ const Details = ({itemId, initialItem, onPlay, onSelectItem, onSelectPerson, onI
 
 	const closeModal = useCallback(() => {
 		setActiveModal(null);
+		window.requestAnimationFrame(() => {
+		  if (lastFocusedElementRef.current) {
+				Spotlight.focus(lastFocusedElementRef.current);
+			}
+		});
 	}, []);
 
 	const handleSelectAudio = useCallback((e) => {

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -963,7 +963,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 	// ==============================
 	// Controls Auto-hide
 	// ==============================
-	const showControls = useCallback(() => {
+	const showControls = useCallback((isModalOpen = activeModal) => {
 		setControlsVisible(true);
 		if (controlsTimeoutRef.current) {
 			clearTimeout(controlsTimeoutRef.current);

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -143,6 +143,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 	const healthMonitorRef = useRef(null);
 	const unregisterAppStateRef = useRef(null);
 	const controlsTimeoutRef = useRef(null);
+	const lastFocusedElementRef = useRef(null);
 	const timeUpdateIntervalRef = useRef(null);
 	const avplayReadyRef = useRef(false);
 	// Refs for stable callbacks inside AVPlay listener (avoids stale closures)
@@ -968,11 +969,9 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			clearTimeout(controlsTimeoutRef.current);
 		}
 		// Don't auto-hide controls in audio mode
-		if (!isAudioMode) {
+		if (!isAudioMode && !isModalOpen) {
 			controlsTimeoutRef.current = setTimeout(() => {
-				if (!activeModal) {
-					setControlsVisible(false);
-				}
+			  setControlsVisible(false);
 			}, CONTROLS_HIDE_DELAY);
 		}
 	}, [activeModal, isAudioMode]);
@@ -1232,10 +1231,10 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 	// Modal handlers
 	const openModal = useCallback((modal) => {
+	  lastFocusedElementRef.current = document.activeElement;
 		setActiveModal(modal);
 		window.requestAnimationFrame(() => {
 			const modalId = `${modal}-modal`;
-
 			const focusResult = Spotlight.focus(modalId);
 
 			if (!focusResult) {
@@ -1252,9 +1251,13 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 	const closeModal = useCallback(() => {
 		setActiveModal(null);
-		showControls();
+		showControls(false);
 		window.requestAnimationFrame(() => {
-			Spotlight.focus('player-controls');
+		  if (lastFocusedElementRef.current) {
+				Spotlight.focus(lastFocusedElementRef.current);
+			}else{
+			  Spotlight.focus('playerControls');
+			}
 		});
 	}, [showControls]);
 

--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -136,8 +136,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 	}, [lyricsLines, currentTime]);
 
 	const lyricsScrollRef = useRef(null);
-
-
+	const lastFocusedElementRef = useRef(null);
 
 	const videoRef = useRef(null);
 	const containerRef = useRef(null);
@@ -1144,16 +1143,14 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 		};
 	}, [mediaUrl, isLoading, mimeType, playMethod, error]);
 
-	const showControls = useCallback(() => {
+	const showControls = useCallback((isModalOpen = activeModal) => {
 		setControlsVisible(true);
 		if (controlsTimeoutRef.current) {
 			clearTimeout(controlsTimeoutRef.current);
 		}
-		if (!isAudioMode) {
+		if (!isAudioMode && !isModalOpen) {
 			controlsTimeoutRef.current = setTimeout(() => {
-				if (!activeModal) {
-					setControlsVisible(false);
-				}
+			  setControlsVisible(false);
 			}, CONTROLS_HIDE_DELAY);
 		}
 	}, [activeModal, isAudioMode]);
@@ -1629,10 +1626,10 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 	}, [settings.skipForwardLength, settings.seekStep, seekByOffset, isInGroup]);
 
 	const openModal = useCallback((modal) => {
+	  lastFocusedElementRef.current = document.activeElement;
 		setActiveModal(modal);
 		window.requestAnimationFrame(() => {
 			const modalId = `${modal}-modal`;
-
 			const focusResult = Spotlight.focus(modalId);
 
 			if (!focusResult) {
@@ -1649,9 +1646,13 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 	const closeModal = useCallback(() => {
 		setActiveModal(null);
-		showControls();
+		showControls(false);
 		window.requestAnimationFrame(() => {
-			Spotlight.focus('player-controls');
+		  if (lastFocusedElementRef.current) {
+				Spotlight.focus(lastFocusedElementRef.current);
+			}else{
+			  Spotlight.focus('playerControls');
+			}
 		});
 	}, [showControls]);
 


### PR DESCRIPTION
# Pull Request

## Summary
1. Focus is not lost anymore and will stay on the selected item after a modal is closed. 
2. After a modal was opened the player controls won't hide, this doesn't happen anymore.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #203 and #214
- Fixes #203 and #214

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- added focus tracking ref, to set the focus back to the item it was before a modal was opened
- changed showControls a little bit to synchronously set modal state

## Platform
- [x] Tizen (Samsung)
- [x] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. click on subtitle selection on player/details page
3. close the selection/select something
4. focus should be back to subtitle selection and not nowhere

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
