### PR TITLE
Fix Jellyseerr advanced request popup and cancel dialog layout

### DIFF
--- a/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
+++ b/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
@@ -655,17 +655,28 @@ const CancelRequestPopup = memo(({open, pendingRequests, title, onConfirm, onClo
 		return $L('Cancel {parts} requests for "{title}"?').replace('{parts}', partsStr).replace('{title}', title);
 	}, [pendingRequests, title]);
 
+	useEffect(() => {
+		if (!open) return;
+		window.requestAnimationFrame(() => {
+			safeFocus('cancel-request-keep');
+		});
+	}, [open]);
+
 	return (
 		<Popup open={open} onClose={onClose} position="center" className={css.cancelPopup}>
 			<div className={css.cancelPopupContent}>
 				<h2 className={css.cancelPopupTitle}>{$L('Cancel Request')}</h2>
 				<p className={css.cancelPopupDescription}>{description}</p>
 				<div className={css.cancelButtons}>
+					<Button
+						className={css.cancelKeepButton}
+						spotlightId="cancel-request-keep"
+						onClick={onClose}
+					>
+						{$L('Keep Request')}
+					</Button>
 					<Button className={css.cancelConfirmButton} onClick={onConfirm}>
 						{$L('Cancel Request')}
-					</Button>
-					<Button className={css.cancelKeepButton} onClick={onClose}>
-						{$L('Keep Request')}
 					</Button>
 				</div>
 			</div>

--- a/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
+++ b/packages/app/src/views/JellyseerrDetails/JellyseerrDetails.js
@@ -483,7 +483,7 @@ const AdvancedOptionsPopup = memo(({open, title, servers, is4k, onConfirm, onClo
 	}, [open, availableServers]);
 
 	useEffect(() => {
-		if (!selectedServerId || !open) return;
+		if (selectedServerId == null || !open) return;
 
 		const loadServerDetails = async () => {
 			setLoadingDetails(true);


### PR DESCRIPTION
# Pull Request

## Summary

Two small fixes in the Jellyseerr details view. The "Continue with Options" path in the Request Options popup was unreachable when the user's only Radarr/Sonarr server in Seerr had `id: 0`, the load effect bailed out on a falsy-zero check, so the server details fetch never ran, no profiles/root folders were available, and "Continue with Options" was silently equivalent to "Use Defaults". Also the Cancel Request popup auto-focused the destructive action and overflowed its container when re-ordered, so Keep Request now gets initial focus and the popup grows to fit both buttons.

## Related Issues

N/A: surfaced while testing the Jellyseerr request flow against a real Radarr server whose Seerr-side id was 0.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- `JellyseerrDetails.js`: replace `if (!selectedServerId || !open) return;` with `if (selectedServerId == null || !open) return;` in `AdvancedOptionsPopup`'s server-details load effect. `!0` was treating a legitimate server id as "nothing selected", so `GET /service/radarr/0` never fired.
- `JellyseerrDetails.js` (CancelRequestPopup): swap button order so "Keep Request" renders first, add `spotlightId` and an `useEffect` that calls `safeFocus('cancel-request-keep')` via `requestAnimationFrame` when the popup opens, matching the focus pattern used in this file.
- `JellyseerrDetails.module.less`: drop `max-width: 400px` from `.cancelPopupContent` so the popup grows to fit two Sandstone `<Button>`s side-by-side.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Verified on an LG webOS TV against a live Jellyseerr instance with just one Radarr server.

### Test Steps
1. Open the Moonfin Jellyseerr Details view for any movie that's requestable, with a Seerr account that has the "Request Advanced" permission and a single Radarr server configured (id 0 to actually see the failing case working now).
2. Press the **Request** button. When the **Request Options** popup appears, confirm the Quality Profile and Download Location sections populate and "Continue with Options" is enabled. Submitting it produces a request with the chosen profile/root folder in Seerr → Requests.
3. With a request already pending, press the **Cancel Request** action on the same details screen. Confirm the popup grows to fit both buttons side-by-side.

## Screenshots

Before:empty "Request Options" popup, "Continue with Options" disabled even though the user had advanced permissions:

<img width="355" height="273" alt="Request Options" src="https://github.com/user-attachments/assets/8d6c2cdc-e662-49a0-9948-ea2e3494086d" />

After: Request Options populated with Quality Profile + Download Location pickers.

<img width="427" height="317" alt="Request Options" src="https://github.com/user-attachments/assets/32cd2e18-6007-4c70-9ed5-d6aac80074f8" />

Before: Cancel Request popup with destructive action auto-focused and the second button overflowing the popup card:

<img width="451" height="235" alt="s later to" src="https://github.com/user-attachments/assets/8d2b08f1-ecb6-4006-a31b-9bdc59049538" />

After: Keep Request focused on the left, Cancel Request on the right, both inside the popup card.
<img width="490" height="227" alt="Cancel Request" src="https://github.com/user-attachments/assets/0d25663b-f256-494d-a479-93f2c71ff145" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced