### PR TITLE
TrueHD and DTS fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40162,6 +40162,124 @@
 				"node": ">=14.15.1"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/code-frame": {
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+			"extraneous": true,
+			"dependencies": {
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/code-frame/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"extraneous": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/code-frame/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"extraneous": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/code-frame/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"extraneous": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/helper-validator-identifier": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/highlight": {
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"extraneous": true,
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/highlight/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"extraneous": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/highlight/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"extraneous": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@babel/highlight/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"extraneous": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+			"extraneous": true
+		},
 		"node_modules/@webos-tools/cli/node_modules/abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -40179,6 +40297,27 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"extraneous": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"extraneous": true,
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/ajv": {
@@ -40277,11 +40416,101 @@
 				"readable-stream": "^2.0.6"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"extraneous": true,
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/argparse/node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/array-buffer-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"is-array-buffer": "^3.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/array-includes": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
+			"integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"get-intrinsic": "^1.2.1",
+				"is-string": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/array.prototype.flat": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
+			"integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"es-shim-unscopables": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/arraybuffer.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+			"extraneous": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.2.1",
+				"get-intrinsic": "^1.2.3",
+				"is-array-buffer": "^3.0.4",
+				"is-shared-array-buffer": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/asn1": {
 			"version": "0.2.6",
@@ -40301,6 +40530,15 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/async": {
 			"version": "3.2.5",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
@@ -40312,6 +40550,21 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"extraneous": true,
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/aws-sign2": {
 			"version": "0.7.0",
@@ -40532,6 +40785,34 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/call-bind": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"extraneous": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -40653,6 +40934,15 @@
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/colors": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+			"integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -40703,6 +40993,15 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha512-OKZnPGeMQy2RPaUIBPFFd71iNf4791H12MCRuVQDnzGRwCYNYmTDy5pdafo2SLAcEMKzTOQnLWG4QdcjeJUMEg==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/content-disposition": {
 			"version": "0.5.3",
@@ -40759,6 +41058,31 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"extraneous": true,
+			"dependencies": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			},
+			"engines": {
+				"node": ">=4.8"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/cross-spawn/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"extraneous": true,
+			"bin": {
+				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/csv-writer": {
@@ -40884,6 +41208,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"extraneous": true
+		},
 		"node_modules/@webos-tools/cli/node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -40894,6 +41224,40 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"extraneous": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"extraneous": true,
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/delayed-stream": {
@@ -40925,6 +41289,18 @@
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/doctrine": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+			"extraneous": true,
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/easy-table": {
 			"version": "1.1.1",
@@ -41014,6 +41390,131 @@
 			"integrity": "sha512-zPlHN59VLEjeJtpEU41ti/i7ZvTbwclvUN2M8anCsI3tOC/3mq6WNTJEKi49A5eLGvDkA0975LZb67Xwp7u4xQ==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"extraneous": true,
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/es-abstract": {
+			"version": "1.22.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.5.tgz",
+			"integrity": "sha512-oW69R+4q2wG+Hc3KZePPZxOiisRIqfKBVo/HLx94QcJeWGU/8sZhCvc829rd1kS366vlJbzBfXf9yWwf0+Ko7w==",
+			"extraneous": true,
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.3",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"es-set-tostringtag": "^2.0.3",
+				"es-to-primitive": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.4",
+				"get-symbol-description": "^1.0.2",
+				"globalthis": "^1.0.3",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.1",
+				"internal-slot": "^1.0.7",
+				"is-array-buffer": "^3.0.4",
+				"is-callable": "^1.2.7",
+				"is-negative-zero": "^2.0.3",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.3",
+				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.13",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.13.1",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.5",
+				"regexp.prototype.flags": "^1.5.2",
+				"safe-array-concat": "^1.1.0",
+				"safe-regex-test": "^1.0.3",
+				"string.prototype.trim": "^1.2.8",
+				"string.prototype.trimend": "^1.0.7",
+				"string.prototype.trimstart": "^1.0.7",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-length": "^1.0.1",
+				"typed-array-byte-offset": "^1.0.2",
+				"typed-array-length": "^1.0.5",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"extraneous": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/es-set-tostringtag": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"extraneous": true,
+			"dependencies": {
+				"get-intrinsic": "^1.2.4",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/es-shim-unscopables": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+			"integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
+			"extraneous": true,
+			"dependencies": {
+				"hasown": "^2.0.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"extraneous": true,
+			"dependencies": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -41027,6 +41528,370 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint": {
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+			"integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+			"extraneous": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"ajv": "^6.10.0",
+				"chalk": "^2.1.0",
+				"cross-spawn": "^6.0.5",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"eslint-scope": "^5.0.0",
+				"eslint-utils": "^1.4.3",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.2",
+				"esquery": "^1.0.1",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^5.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob-parent": "^5.0.0",
+				"globals": "^12.1.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^7.0.0",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.3.0",
+				"lodash": "^4.17.14",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.3",
+				"progress": "^2.0.0",
+				"regexpp": "^2.0.1",
+				"semver": "^6.1.2",
+				"strip-ansi": "^5.2.0",
+				"strip-json-comments": "^3.0.1",
+				"table": "^5.2.3",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-import-resolver-node": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+			"integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+			"extraneous": true,
+			"dependencies": {
+				"debug": "^3.2.7",
+				"is-core-module": "^2.13.0",
+				"resolve": "^1.22.4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-import-resolver-node/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"extraneous": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-import-resolver-node/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-module-utils": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
+			"integrity": "sha512-rXDXR3h7cs7dy9RNpUlQf80nX31XWJEyGq1tRMo+6GsO5VmTe4UTwtmonAD4ZkAsrfMVDA2wlGJ3790Ys+D49Q==",
+			"extraneous": true,
+			"dependencies": {
+				"debug": "^3.2.7"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-module-utils/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"extraneous": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-module-utils/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-plugin-import": {
+			"version": "2.22.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
+			"integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+			"extraneous": true,
+			"dependencies": {
+				"array-includes": "^3.1.1",
+				"array.prototype.flat": "^1.2.3",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.3",
+				"eslint-module-utils": "^2.6.0",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.1",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.17.0",
+				"tsconfig-paths": "^3.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-plugin-import/node_modules/doctrine": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+			"integrity": "sha512-lsGyRuYr4/PIB0txi+Fy2xOMI2dGaTguCaotzFGkVZuKR5usKfcRWIFKNM3QNrU7hh/+w2bwTW+ZeXPK5l8uVg==",
+			"extraneous": true,
+			"dependencies": {
+				"esutils": "^2.0.2",
+				"isarray": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"extraneous": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-utils": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+			"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+			"extraneous": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint-visitor-keys": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint/node_modules/ansi-regex": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"extraneous": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"extraneous": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"extraneous": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint/node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"extraneous": true,
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"extraneous": true,
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/eslint/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"extraneous": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/espree": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+			"extraneous": true,
+			"dependencies": {
+				"acorn": "^7.1.1",
+				"acorn-jsx": "^5.2.0",
+				"eslint-visitor-keys": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"extraneous": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/esquery": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"extraneous": true,
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/esquery/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"extraneous": true,
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/esrecurse/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/etag": {
@@ -41141,6 +42006,12 @@
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"extraneous": true
+		},
 		"node_modules/@webos-tools/cli/node_modules/fd-slicer": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -41163,6 +42034,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/file-entry-cache": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+			"integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+			"extraneous": true,
+			"dependencies": {
+				"flat-cache": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/file-type": {
@@ -41204,6 +42087,18 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+			"extraneous": true,
+			"dependencies": {
+				"locate-path": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/first-chunk-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
@@ -41211,6 +42106,47 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/flat-cache": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+			"integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+			"extraneous": true,
+			"dependencies": {
+				"flatted": "^2.0.0",
+				"rimraf": "2.6.3",
+				"write": "1.0.3"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/flat-cache/node_modules/rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"extraneous": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/flatted": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"extraneous": true,
+			"dependencies": {
+				"is-callable": "^1.1.3"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/forever-agent": {
@@ -41360,6 +42296,39 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/function.prototype.name": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/functional-red-black-tree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"extraneous": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/gauge": {
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -41402,6 +42371,25 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"extraneous": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/get-stream": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
@@ -41413,6 +42401,23 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/get-symbol-description": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/getpass": {
@@ -41462,6 +42467,48 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/globals": {
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+			"integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+			"extraneous": true,
+			"dependencies": {
+				"type-fest": "^0.8.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/globalthis": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+			"integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+			"extraneous": true,
+			"dependencies": {
+				"define-properties": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"extraneous": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -41491,6 +42538,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/has": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+			"integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -41512,6 +42568,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"extraneous": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -41519,6 +42584,57 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"extraneous": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/has-proto": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"extraneous": true,
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/has-unicode": {
@@ -41538,6 +42654,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/hosted-git-info": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"extraneous": true
 		},
 		"node_modules/@webos-tools/cli/node_modules/http-errors": {
 			"version": "1.7.2",
@@ -41607,6 +42729,40 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/@webos-tools/cli/node_modules/ignore": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/import-fresh": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"extraneous": true,
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/inflight": {
 			"version": "1.0.6",
@@ -41707,6 +42863,20 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/internal-slot": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+			"extraneous": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.0",
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/interpret": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
@@ -41725,6 +42895,40 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/is-array-buffer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"extraneous": true,
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -41737,6 +42941,34 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/is-core-module": {
 			"version": "2.13.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
@@ -41744,6 +42976,21 @@
 			"dev": true,
 			"dependencies": {
 				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"extraneous": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -41794,6 +43041,18 @@
 			"integrity": "sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -41803,6 +43062,52 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"extraneous": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-regex": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-shared-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -41810,6 +43115,51 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"extraneous": true,
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"extraneous": true,
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/is-typed-array": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+			"extraneous": true,
+			"dependencies": {
+				"which-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/is-typedarray": {
@@ -41836,17 +43186,91 @@
 			"integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"extraneous": true
+		},
 		"node_modules/@webos-tools/cli/node_modules/isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/jasmine": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.8.0.tgz",
+			"integrity": "sha512-kdQ3SfcNpMbbMdgJPLyFe9IksixdnrgYaCJapP9sS0aLgdWdIZADNXEr+11Zafxm1VDfRSC5ZL4fzXT0bexzXw==",
+			"extraneous": true,
+			"dependencies": {
+				"glob": "^7.1.6",
+				"jasmine-core": "~3.8.0"
+			},
+			"bin": {
+				"jasmine": "bin/jasmine.js"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/jasmine-core": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.8.0.tgz",
+			"integrity": "sha512-zl0nZWDrmbCiKns0NcjkFGYkVTGCPUgoHypTaj+G2AzaWus7QGoXARSlYsSle2VRpSdfJmM+hzmFKzQNhF2kHg==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/jasmine-pretty-html-reporter-jasmine3.8": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/jasmine-pretty-html-reporter-jasmine3.8/-/jasmine-pretty-html-reporter-jasmine3.8-0.2.5.tgz",
+			"integrity": "sha512-MbjwlL1ssRjJM93fM58nDnsO1/IO0VhH7FZ6uOlZShq47a8GjffCr4DBlN1P9NU6icXLxukbd/vaPJoKCIw8NQ==",
+			"extraneous": true,
+			"peerDependencies": {
+				"jasmine": "^3.8.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/jasmine-spec-reporter": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz",
+			"integrity": "sha512-FZBoZu7VE5nR7Nilzy+Np8KuVIOxF4oXDPDknehCYBDE080EnlPu0afdZNmpGDBRCUBv3mj5qgqCRmk6W/K8vg==",
+			"extraneous": true,
+			"dependencies": {
+				"colors": "1.1.2"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/js-yaml": {
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"extraneous": true,
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/jsbn": {
 			"version": "0.1.1",
@@ -41866,11 +43290,29 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"extraneous": true
+		},
 		"node_modules/@webos-tools/cli/node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/json5": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+			"extraneous": true,
+			"dependencies": {
+				"minimist": "^1.2.0"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/jsonfile": {
 			"version": "4.0.0",
@@ -41903,6 +43345,56 @@
 			},
 			"engines": {
 				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+			"extraneous": true,
+			"dependencies": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/load-json-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+			"integrity": "sha512-3p6ZOGNbiX4CdvEd1VcE6yi78UrGNpjHO33noGwHCnT/o2fyllJDepsm8+mFFv/DvtwFHht5HIHSyOy5a+ChVQ==",
+			"extraneous": true,
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/load-json-file/node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+			"extraneous": true,
+			"dependencies": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/lodash": {
@@ -42170,6 +43662,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"extraneous": true
+		},
 		"node_modules/@webos-tools/cli/node_modules/negotiator": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -42178,6 +43676,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"extraneous": true
 		},
 		"node_modules/@webos-tools/cli/node_modules/nopt": {
 			"version": "2.1.2",
@@ -42189,6 +43693,27 @@
 			},
 			"bin": {
 				"nopt": "bin/nopt.js"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"extraneous": true,
+			"dependencies": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/normalize-package-data/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"extraneous": true,
+			"bin": {
+				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/normalize-path": {
@@ -42239,6 +43764,59 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/object-inspect": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"extraneous": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/object.assign": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/object.values": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
+			"integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/on-finished": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -42273,6 +43851,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/optionator": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+			"extraneous": true,
+			"dependencies": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.6",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"word-wrap": "~1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/ora": {
@@ -42398,6 +43993,63 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/p-limit": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"extraneous": true,
+			"dependencies": {
+				"p-try": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+			"extraneous": true,
+			"dependencies": {
+				"p-limit": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"extraneous": true,
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/parse-json": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+			"integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
+			"extraneous": true,
+			"dependencies": {
+				"error-ex": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -42407,6 +44059,15 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -42414,6 +44075,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/path-parse": {
@@ -42427,6 +44097,18 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
 			"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/path-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+			"integrity": "sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ==",
+			"extraneous": true,
+			"dependencies": {
+				"pify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/pend": {
 			"version": "1.2.0",
@@ -42482,11 +44164,38 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/possible-typed-array-names": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+			"extraneous": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/proxy-addr": {
 			"version": "2.0.7",
@@ -42549,6 +44258,33 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/read-pkg": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+			"integrity": "sha512-eFIBOPW7FGjzBuk3hdXEuNSiTZS/xEMlH49HxMyzb0hyPfu4EhVjT2DH32K1hSSmVq4sebAWnZuuY5auISUTGA==",
+			"extraneous": true,
+			"dependencies": {
+				"load-json-file": "^2.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/read-pkg-up": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+			"integrity": "sha512-1orxQfbWGUiTn9XsPlChs6rLie/AV9jwZTGmu2NZw/CUDJQchXJFYE0Fq5j7+n558T1JhDWLdhyd1Zj+wLY//w==",
+			"extraneous": true,
+			"dependencies": {
+				"find-up": "^2.0.0",
+				"read-pkg": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/readable-stream": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -42592,6 +44328,33 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/regexp.prototype.flags": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+			"integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"set-function-name": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/regexpp": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=6.5.0"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/request": {
@@ -42652,6 +44415,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/restore-cursor": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -42701,11 +44473,52 @@
 				"npm": ">=2.0.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/safe-array-concat": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+			"integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"get-intrinsic": "^1.2.2",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/safe-array-concat/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"extraneous": true
+		},
 		"node_modules/@webos-tools/cli/node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/safe-regex-test": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.1.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/safer-buffer": {
 			"version": "2.1.2",
@@ -42789,11 +44602,64 @@
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/set-function-length": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
+			"integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+			"extraneous": true,
+			"dependencies": {
+				"define-data-property": "^1.1.2",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.3",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"extraneous": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/setprototypeof": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
 			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+			"extraneous": true,
+			"dependencies": {
+				"shebang-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/shelljs": {
 			"version": "0.8.5",
@@ -42812,11 +44678,64 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/side-channel": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/slice-ansi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+			"integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+			"extraneous": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.0",
+				"astral-regex": "^1.0.0",
+				"is-fullwidth-code-point": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/slice-ansi/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"extraneous": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/source-map": {
 			"version": "0.6.1",
@@ -42836,6 +44755,38 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/spdx-correct": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+			"extraneous": true,
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"extraneous": true,
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/spdx-license-ids": {
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+			"integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
+			"extraneous": true
 		},
 		"node_modules/@webos-tools/cli/node_modules/sprintf-js": {
 			"version": "1.1.2",
@@ -42954,6 +44905,51 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/string.prototype.trim": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
+			"integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/string.prototype.trimend": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
+			"integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/string.prototype.trimstart": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
+			"integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/strip-ansi": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -43000,6 +44996,18 @@
 				"is-natural-number": "^4.0.1"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/supports-color": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -43019,6 +45027,71 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/table": {
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+			"extraneous": true,
+			"dependencies": {
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
+				"slice-ansi": "^2.1.0",
+				"string-width": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/table/node_modules/ansi-regex": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/table/node_modules/emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/table/node_modules/is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/table/node_modules/string-width": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+			"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+			"extraneous": true,
+			"dependencies": {
+				"emoji-regex": "^7.0.1",
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/table/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"extraneous": true,
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/tar": {
@@ -43119,6 +45192,12 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/text-table": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+			"extraneous": true
+		},
 		"node_modules/@webos-tools/cli/node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -43177,6 +45256,27 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/tsconfig-paths": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+			"integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+			"extraneous": true,
+			"dependencies": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.2",
+				"minimist": "^1.2.6",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/tsconfig-paths/node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -43201,6 +45301,27 @@
 			"integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
 			"dev": true
 		},
+		"node_modules/@webos-tools/cli/node_modules/type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+			"extraneous": true,
+			"dependencies": {
+				"prelude-ls": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/type-is": {
 			"version": "1.6.18",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -43214,11 +45335,99 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/typed-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/typed-array-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/typed-array-byte-offset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+			"extraneous": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/typed-array-length": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.5.tgz",
+			"integrity": "sha512-yMi0PlwuznKHxKmcpoOdeLwxBoVPkqZxd7q2FgMkmD3bNwvF5VW0+UlUQ1k1vmktTu4Yu13Q0RIxEP8+B+wloA==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/unbox-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"extraneous": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/unbzip2-stream": {
 			"version": "1.4.3",
@@ -43282,6 +45491,22 @@
 				"uuid": "bin/uuid"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/v8-compile-cache": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz",
+			"integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==",
+			"extraneous": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"extraneous": true,
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -43320,6 +45545,53 @@
 				"defaults": "^1.0.3"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"extraneous": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"extraneous": true,
+			"dependencies": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/@webos-tools/cli/node_modules/which-typed-array": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
+			"integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+			"extraneous": true,
+			"dependencies": {
+				"available-typed-arrays": "^1.0.6",
+				"call-bind": "^1.0.5",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/wide-align": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -43329,11 +45601,32 @@
 				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
+		"node_modules/@webos-tools/cli/node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"extraneous": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/@webos-tools/cli/node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
+		},
+		"node_modules/@webos-tools/cli/node_modules/write": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+			"integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+			"extraneous": true,
+			"dependencies": {
+				"mkdirp": "^0.5.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/@webos-tools/cli/node_modules/xtend": {
 			"version": "4.0.2",

--- a/packages/app/src/App/App.js
+++ b/packages/app/src/App/App.js
@@ -15,6 +15,7 @@ import {JellyseerrProvider} from '../context/JellyseerrContext';
 import {SyncPlayProvider, useSyncPlay} from '../context/SyncPlayContext';
 import {useVersionCheck} from '../hooks/useVersionCheck';
 import UpdateNotification from '../components/UpdateNotification';
+import DebugOverlay from '../components/DebugOverlay'; // Red Button on TV remote toggles this
 import NavBar from '../components/NavBar';
 import Sidebar from '../components/Sidebar';
 import AccountModal from '../components/AccountModal';
@@ -1036,6 +1037,7 @@ const AppContent = (props) => {
 			/>
 			<SeasonalTheme theme={settings.seasonalTheme} />
 			<NoConnection />
+			<DebugOverlay />
 			{connectionState !== 'connected' && isAuthenticated && (
 				<div className={css.connectionBanner}>
 					<span>{connectionState === 'reconnecting' ? 'Reconnecting to server...' : 'Lost connection to server'}</span>

--- a/packages/app/src/components/DebugOverlay/DebugOverlay.js
+++ b/packages/app/src/components/DebugOverlay/DebugOverlay.js
@@ -47,7 +47,6 @@ installHooks();
 const KEY_RED = 403;
 const KEY_GREEN = 404;
 const KEY_YELLOW = 405;
-const KEY_BLUE = 406;
 
 const colorForLevel = (level) => {
 	if (level === 'E') return '#ff6b6b';

--- a/packages/app/src/components/DebugOverlay/DebugOverlay.js
+++ b/packages/app/src/components/DebugOverlay/DebugOverlay.js
@@ -1,0 +1,134 @@
+import {useEffect, useRef, useState} from 'react';
+
+// Simple Debugger that shows on the right side the consol of the TV
+// Red button on rmeote toggles it
+
+const MAX_LINES = 200;
+
+const buffer = [];
+const listeners = new Set();
+let installed = false;
+
+const stringify = (value) => {
+	if (value instanceof Error) return value.stack || value.message;
+	if (typeof value === 'string') return value;
+	if (typeof value === 'number' || typeof value === 'boolean' || value == null) return String(value);
+	try { return JSON.stringify(value); }
+	catch { return Object.prototype.toString.call(value); }
+};
+
+const push = (level, args) => {
+	const ts = new Date().toISOString().slice(11, 23);
+	const text = Array.prototype.map.call(args, stringify).join(' ');
+	buffer.push({ts, level, text});
+	if (buffer.length > MAX_LINES) buffer.splice(0, buffer.length - MAX_LINES);
+	listeners.forEach((fn) => { try { fn(); } catch { /* ignore */ } });
+};
+
+const installHooks = () => {
+	if (installed || typeof window === 'undefined') return;
+	installed = true;
+	const orig = {
+		log: console.log.bind(console),
+		info: console.info.bind(console),
+		warn: console.warn.bind(console),
+		error: console.error.bind(console)
+	};
+	console.log = function () { push('L', arguments); orig.log.apply(null, arguments); };
+	console.info = function () { push('I', arguments); orig.info.apply(null, arguments); };
+	console.warn = function () { push('W', arguments); orig.warn.apply(null, arguments); };
+	console.error = function () { push('E', arguments); orig.error.apply(null, arguments); };
+	window.addEventListener('error', (e) => push('E', [`window.onerror: ${e.message} @ ${e.filename}:${e.lineno}`]));
+	window.addEventListener('unhandledrejection', (e) => push('E', [`unhandledrejection: ${stringify(e.reason)}`]));
+};
+
+installHooks();
+
+const KEY_RED = 403;
+const KEY_GREEN = 404;
+const KEY_YELLOW = 405;
+const KEY_BLUE = 406;
+
+const colorForLevel = (level) => {
+	if (level === 'E') return '#ff6b6b';
+	if (level === 'W') return '#ffd166';
+	if (level === 'I') return '#7fc8ff';
+	return '#d0d0d0';
+};
+
+const DebugOverlay = () => {
+	const [visible, setVisible] = useState(false);
+	const [, force] = useState(0);
+	const preRef = useRef(null);
+
+	useEffect(() => {
+		const onChange = () => force((n) => (n + 1) % 1000000);
+		listeners.add(onChange);
+		return () => { listeners.delete(onChange); };
+	}, []);
+
+	useEffect(() => {
+		const onKey = (e) => {
+			const code = e.keyCode || e.which;
+			if (code === KEY_RED) { setVisible((v) => !v); e.preventDefault(); e.stopPropagation(); }
+			else if (code === KEY_GREEN) { buffer.length = 0; force((n) => n + 1); e.preventDefault(); e.stopPropagation(); }
+			else if (code === KEY_YELLOW) {
+				// Dump buffer to localStorage so we can retrieve later
+				try { localStorage.setItem('moonfin_debug_log', JSON.stringify(buffer)); } catch { /* ignore */ }
+				push('I', ['[debug] saved log to localStorage moonfin_debug_log']);
+				e.preventDefault(); e.stopPropagation();
+			}
+		};
+		window.addEventListener('keydown', onKey, true);
+		return () => window.removeEventListener('keydown', onKey, true);
+	}, []);
+
+	useEffect(() => {
+		if (visible && preRef.current) {
+			preRef.current.scrollTop = preRef.current.scrollHeight;
+		}
+	});
+
+	if (!visible) return null;
+
+	return (
+		<div
+			style={{
+				position: 'fixed',
+				top: 0,
+				right: 0,
+				width: '50%',
+				height: '100%',
+				background: 'rgba(0,0,0,0.85)',
+				color: '#d0d0d0',
+				font: '14px/1.3 monospace',
+				zIndex: 2147483647,
+				pointerEvents: 'none',
+				padding: '8px',
+				boxSizing: 'border-box'
+			}}
+		>
+			<div style={{color: '#7fc8ff', marginBottom: 4}}>
+				DEBUG OVERLAY — RED toggle · GREEN clear · YELLOW save · {buffer.length}/{MAX_LINES}
+			</div>
+			<pre
+				ref={preRef}
+				style={{
+					margin: 0,
+					height: 'calc(100% - 24px)',
+					overflowY: 'auto',
+					whiteSpace: 'pre-wrap',
+					wordBreak: 'break-all'
+				}}
+			>
+				{buffer.map((entry, i) => (
+					<div key={i} style={{color: colorForLevel(entry.level)}}>
+						{entry.ts} {entry.level} {entry.text}
+					</div>
+				))}
+			</pre>
+		</div>
+	);
+};
+
+export default DebugOverlay;

--- a/packages/app/src/components/DebugOverlay/index.js
+++ b/packages/app/src/components/DebugOverlay/index.js
@@ -1,0 +1,1 @@
+export {default} from './DebugOverlay';

--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -90,6 +90,10 @@ const defaultSettings = {
 	enablePgsRendering: true,
 	showSyncPlayButton: true,
 	stereoUpmixEnabled: false,
+	passthroughEnabled: true,
+	ac3Passthrough: true,
+	eac3Passthrough: true,
+	truehdPassthrough: true,
 	blockedRatings: [],
 	jellyseerrRows: null
 };

--- a/packages/app/src/services/jellyfinApi.js
+++ b/packages/app/src/services/jellyfinApi.js
@@ -7,6 +7,7 @@ const APP_VERSION = packageJson.version;
 
 const APP_NAME = isTizen() ? 'Moonfin for Tizen' : 'Moonfin for webOS';
 const DEVICE_NAME = isTizen() ? 'Samsung Smart TV' : 'LG Smart TV';
+const platformTag = isTizen() ? 'tizen' : 'webos';
 
 let deviceId = null;
 let currentServer = null;
@@ -42,7 +43,7 @@ export const initDeviceId = async () => {
 		// Storage not available
 	}
 
-	deviceId = 'moonfin_webos_' + Date.now().toString(36) + Math.random().toString(36).substring(2);
+	deviceId = `moonfin_${platformTag}_` + Date.now().toString(36) + Math.random().toString(36).substring(2);
 
 	try {
 		const {saveToStorage} = await import('./storage');

--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -1,12 +1,24 @@
 import * as jellyfinApi from './jellyfinApi';
 import {getJellyfinDeviceProfile, getDeviceCapabilities} from './deviceProfile';
-import {getPlayMethod, getMimeType, findCompatibleAudioStreamIndex, getSupportedAudioCodecs} from './video';
+import {getPlayMethod, getMimeType, findCompatibleAudioStreamIndex, isAudioStreamPlayable} from './video';
 import {getFromStorage} from './storage';
 
 export const PlayMethod = {
 	DirectPlay: 'DirectPlay',
 	DirectStream: 'DirectStream',
 	Transcode: 'Transcode'
+};
+
+// This is for the TranscodeKillr Plugin witch needs a Tag or else the audio remux only will be killed aftr 10 seconds
+const isAudioOnlyRemuxTranscode = (mediaSource) => {
+	if (!mediaSource?.TranscodingUrl) return false;
+	const videoStream = (mediaSource.MediaStreams || []).find((s) => s.Type === 'Video');
+	if (!videoStream?.Codec) return false;
+	const match = mediaSource.TranscodingUrl.match(/[?&]VideoCodec=([^&]+)/i);
+	if (!match) return false;
+	const allowed = decodeURIComponent(match[1]).toLowerCase().split(',').map((c) => c.trim());
+	const sourceCodec = videoStream.Codec.toLowerCase();
+	return allowed.includes('copy') || allowed.includes(sourceCodec);
 };
 
 let currentSession = null;
@@ -27,7 +39,7 @@ const getPlaybackAudioSettings = async (options = {}) => {
 		return {...DEFAULT_PASSTHROUGH_SETTINGS, ...options.passthroughSettings};
 	}
 
-	const stored = await getFromStorage('settings', {});
+	const stored = (await getFromStorage('settings')) || {};
 	return {
 		passthroughEnabled: options.passthroughEnabled ?? stored.passthroughEnabled ?? DEFAULT_PASSTHROUGH_SETTINGS.passthroughEnabled,
 		ac3Passthrough: options.ac3Passthrough ?? stored.ac3Passthrough ?? DEFAULT_PASSTHROUGH_SETTINGS.ac3Passthrough,
@@ -89,9 +101,7 @@ const selectMediaSource = (mediaSources, capabilities, options, passthroughSetti
 
 		// Score based on the best COMPATIBLE audio stream, not just the first one
 		const sourceAudioStreams = source.MediaStreams?.filter(s => s.Type === 'Audio') || [];
-		const sourceContainer = (source.Container || '').toLowerCase();
-		const supportedAudio = getSupportedAudioCodecs(capabilities, sourceContainer, passthroughSettings);
-		const compatibleAudio = sourceAudioStreams.filter(s => supportedAudio.includes((s.Codec || '').toLowerCase()));
+		const compatibleAudio = sourceAudioStreams.filter(s => isAudioStreamPlayable(s, capabilities, passthroughSettings));
 		if (compatibleAudio.length > 0) {
 			const bestAudio = compatibleAudio.reduce((best, s) => {
 				let trackScore = 0;
@@ -211,6 +221,9 @@ const buildPlaybackUrl = (itemId, mediaSource, playSessionId, playMethod, creden
 		if (options.stereoUpmixEnabled) {
 			transcodeUrl += (transcodeUrl.includes('?') ? '&' : '?') + 'upmix=true';
 		}
+
+		// If a video os alrady in progress a segmented stream response is given so a stratime is not needed
+		transcodeUrl = transcodeUrl.replace(/([?&])StartTimeTicks=[^&]*&?/i, '$1').replace(/[?&]$/, '');
 
 		const url = transcodeUrl.startsWith('http')
 			? transcodeUrl
@@ -418,35 +431,30 @@ export const getPlaybackInfo = async (itemId, options = {}) => {
 			s => s.Type === 'Audio' && s.Index === mediaSource.DefaultAudioStreamIndex
 		);
 		const defaultCodec = (defaultAudioStream?.Codec || '').toLowerCase();
-		const sourceContainer = (mediaSource.Container || '').toLowerCase();
-		const supportedAudio = getSupportedAudioCodecs(capabilities, sourceContainer, passthroughSettings);
+		const defaultPlayable = isAudioStreamPlayable(defaultAudioStream, capabilities, passthroughSettings);
 
-		if (defaultCodec && !supportedAudio.includes(defaultCodec)) {
-			const compatibleIndex = findCompatibleAudioStreamIndex(mediaSource, capabilities, passthroughSettings);
-			if (compatibleIndex >= 0) {
-				console.log(`[playback] Default audio track ${mediaSource.DefaultAudioStreamIndex} (${defaultCodec}) unsupported, auto-selecting compatible track ${compatibleIndex}`);
-				// Re-request playback info with the compatible audio stream so the server
-				// evaluates DirectPlay/DirectStream against the compatible track
-				const retryInfo = await api.getPlaybackInfo(itemId, {
-					DeviceProfile: deviceProfile,
-					StartTimeTicks: requestedStartTime,
-					AutoOpenLiveStream: true,
-					EnableDirectPlay: options.enableDirectPlay !== false,
-					EnableDirectStream: options.enableDirectStream !== false,
-					EnableTranscoding: options.enableTranscoding !== false,
-					AudioStreamIndex: compatibleIndex,
-					SubtitleStreamIndex: subtitleStreamIndex,
-					MaxStreamingBitrate: maxBitrate,
-					MediaSourceId: options.mediaSourceId || mediaSource.Id
-				});
-				if (retryInfo.MediaSources?.length) {
-					mediaSource = selectMediaSource(retryInfo.MediaSources, capabilities, options, passthroughSettings);
-					audioStreamIndex = compatibleIndex;
-					playbackInfo = retryInfo;
-					console.log(`[playback] Re-requested with audio track ${compatibleIndex}, play method: ${determinePlayMethod(mediaSource, capabilities, options, passthroughSettings)}`);
-				}
-			} else {
-				console.warn('[playback] No compatible audio track found \u2014 server will remux/transcode');
+		if (defaultAudioStream && !defaultPlayable) {
+			// Force Transcode if audio stream is unplayable
+			console.log(`[playback] Default audio (${defaultCodec}) unplayable \u2014 forcing transcode (audio-only remux, video copied)`);
+			const retryInfo = await api.getPlaybackInfo(itemId, {
+				DeviceProfile: deviceProfile,
+				StartTimeTicks: requestedStartTime,
+				AutoOpenLiveStream: true,
+				EnableDirectPlay: false,
+				EnableDirectStream: false,
+				EnableTranscoding: true,
+				AudioStreamIndex: mediaSource.DefaultAudioStreamIndex,
+				SubtitleStreamIndex: subtitleStreamIndex,
+				MaxStreamingBitrate: maxBitrate,
+				MediaSourceId: options.mediaSourceId || mediaSource.Id
+			});
+			if (retryInfo.MediaSources?.length) {
+				mediaSource = retryInfo.MediaSources[0];
+				audioStreamIndex = mediaSource.DefaultAudioStreamIndex;
+				playbackInfo = retryInfo;
+				mediaSource.SupportsDirectPlay = false;
+				mediaSource.SupportsDirectStream = false;
+				console.log(`[playback] After audio-remux retry \u2014 TranscodingUrl: ${mediaSource.TranscodingUrl ? 'present' : 'MISSING'}`);
 			}
 		}
 	}
@@ -510,12 +518,16 @@ export const getPlaybackInfo = async (itemId, options = {}) => {
 	const subtitleStreams = extractSubtitleStreams(mediaSource);
 	const chapters = extractChapters(mediaSource);
 
+	const audioOnlyRemux = playMethod === PlayMethod.Transcode && isAudioOnlyRemuxTranscode(mediaSource);
+	const reportedPlayMethod = audioOnlyRemux ? PlayMethod.DirectStream : playMethod;
+
 	currentSession = {
 		itemId,
 		playSessionId: playbackInfo.PlaySessionId,
 		mediaSourceId: mediaSource.Id,
 		mediaSource,
 		playMethod,
+		reportedPlayMethod,
 		startPositionTicks: options.startPositionTicks || 0,
 		capabilities,
 		audioStreamIndex: audioStreamIndex ?? mediaSource.DefaultAudioStreamIndex,
@@ -524,6 +536,9 @@ export const getPlaybackInfo = async (itemId, options = {}) => {
 		serverCredentials: creds
 	};
 
+	if (audioOnlyRemux) {
+		console.log(`[playback] Audio-only remux detected; reporting session as DirectStream (video=copy) for ${itemId}`);
+	}
 	console.log(`[playback] Playing ${itemId} via ${playMethod}`);
 
 	let mimeType;
@@ -862,7 +877,7 @@ export const reportStart = async (positionTicks = 0) => {
 			CanSeek: true,
 			IsPaused: false,
 			IsMuted: false,
-			PlayMethod: currentSession.playMethod,
+			PlayMethod: currentSession.reportedPlayMethod || currentSession.playMethod,
 			RepeatMode: 'RepeatNone'
 		});
 	} catch (e) {
@@ -891,7 +906,7 @@ export const reportProgress = async (positionTicks, options = {}) => {
 			CanSeek: true,
 			IsPaused: options.isPaused || false,
 			IsMuted: options.isMuted || false,
-			PlayMethod: currentSession.playMethod,
+			PlayMethod: currentSession.reportedPlayMethod || currentSession.playMethod,
 			AudioStreamIndex: currentSession.audioStreamIndex,
 			SubtitleStreamIndex: currentSession.subtitleStreamIndex
 		};

--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -1,6 +1,6 @@
 import * as jellyfinApi from './jellyfinApi';
 import {getJellyfinDeviceProfile, getDeviceCapabilities} from './deviceProfile';
-import {getPlayMethod, getMimeType, findCompatibleAudioStreamIndex, isAudioStreamPlayable} from './video';
+import {getPlayMethod, getMimeType, isAudioStreamPlayable} from './video';
 import {getFromStorage} from './storage';
 
 export const PlayMethod = {

--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -1,6 +1,7 @@
 import * as jellyfinApi from './jellyfinApi';
 import {getJellyfinDeviceProfile, getDeviceCapabilities} from './deviceProfile';
 import {getPlayMethod, getMimeType, findCompatibleAudioStreamIndex, getSupportedAudioCodecs} from './video';
+import {getFromStorage} from './storage';
 
 export const PlayMethod = {
 	DirectPlay: 'DirectPlay',
@@ -11,6 +12,31 @@ export const PlayMethod = {
 let currentSession = null;
 let progressInterval = null;
 let healthMonitor = null;
+
+const DEFAULT_PASSTHROUGH_SETTINGS = {
+	passthroughEnabled: true,
+	ac3Passthrough: true,
+	eac3Passthrough: true,
+	dtsPassthrough: true,
+	dtshdPassthrough: true,
+	truehdPassthrough: true
+};
+
+const getPlaybackAudioSettings = async (options = {}) => {
+	if (options.passthroughSettings) {
+		return {...DEFAULT_PASSTHROUGH_SETTINGS, ...options.passthroughSettings};
+	}
+
+	const stored = await getFromStorage('settings', {});
+	return {
+		passthroughEnabled: options.passthroughEnabled ?? stored.passthroughEnabled ?? DEFAULT_PASSTHROUGH_SETTINGS.passthroughEnabled,
+		ac3Passthrough: options.ac3Passthrough ?? stored.ac3Passthrough ?? DEFAULT_PASSTHROUGH_SETTINGS.ac3Passthrough,
+		eac3Passthrough: options.eac3Passthrough ?? stored.eac3Passthrough ?? DEFAULT_PASSTHROUGH_SETTINGS.eac3Passthrough,
+		dtsPassthrough: options.dtsPassthrough ?? stored.dtsPassthrough ?? DEFAULT_PASSTHROUGH_SETTINGS.dtsPassthrough,
+		dtshdPassthrough: options.dtshdPassthrough ?? stored.dtshdPassthrough ?? DEFAULT_PASSTHROUGH_SETTINGS.dtshdPassthrough,
+		truehdPassthrough: options.truehdPassthrough ?? stored.truehdPassthrough ?? DEFAULT_PASSTHROUGH_SETTINGS.truehdPassthrough
+	};
+};
 
 // Cross-server support: get API instance based on item or options
 const getApiForItem = (item) => {
@@ -32,7 +58,7 @@ const getServerCredentials = (item) => {
 	return null;
 };
 
-const selectMediaSource = (mediaSources, capabilities, options) => {
+const selectMediaSource = (mediaSources, capabilities, options, passthroughSettings = DEFAULT_PASSTHROUGH_SETTINGS) => {
 	if (options.mediaSourceId) {
 		const source = mediaSources.find(s => s.Id === options.mediaSourceId);
 		if (source) return source;
@@ -40,7 +66,7 @@ const selectMediaSource = (mediaSources, capabilities, options) => {
 
 	const scored = mediaSources.map(source => {
 		let score = 0;
-		const playMethodResult = getPlayMethod(source, capabilities, options);
+		const playMethodResult = getPlayMethod(source, capabilities, options, passthroughSettings);
 
 		if (playMethodResult === PlayMethod.DirectPlay) score += 1000;
 		else if (playMethodResult === PlayMethod.DirectStream) score += 500;
@@ -64,7 +90,7 @@ const selectMediaSource = (mediaSources, capabilities, options) => {
 		// Score based on the best COMPATIBLE audio stream, not just the first one
 		const sourceAudioStreams = source.MediaStreams?.filter(s => s.Type === 'Audio') || [];
 		const sourceContainer = (source.Container || '').toLowerCase();
-		const supportedAudio = getSupportedAudioCodecs(capabilities, sourceContainer);
+		const supportedAudio = getSupportedAudioCodecs(capabilities, sourceContainer, passthroughSettings);
 		const compatibleAudio = sourceAudioStreams.filter(s => supportedAudio.includes((s.Codec || '').toLowerCase()));
 		if (compatibleAudio.length > 0) {
 			const bestAudio = compatibleAudio.reduce((best, s) => {
@@ -99,7 +125,7 @@ const selectMediaSource = (mediaSources, capabilities, options) => {
 	return scored[0].source;
 };
 
-const determinePlayMethod = (mediaSource, capabilities, options = {}) => {
+const determinePlayMethod = (mediaSource, capabilities, options = {}, passthroughSettings = DEFAULT_PASSTHROUGH_SETTINGS) => {
 	if (options.forceDirectPlay) return PlayMethod.DirectPlay;
 
 	const mediaStreams = mediaSource?.MediaStreams || [];
@@ -112,7 +138,7 @@ const determinePlayMethod = (mediaSource, capabilities, options = {}) => {
 		return PlayMethod.Transcode;
 	}
 
-	const computedMethod = getPlayMethod(mediaSource, capabilities, options);
+	const computedMethod = getPlayMethod(mediaSource, capabilities, options, passthroughSettings);
 	console.log('[playback] determinePlayMethod - computed:', computedMethod,
 		'serverDirectPlay:', mediaSource.SupportsDirectPlay,
 		'serverDirectStream:', mediaSource.SupportsDirectStream,
@@ -262,8 +288,10 @@ const getAutoMaxBitrate = (capabilities) => {
 };
 
 export const getPlaybackInfo = async (itemId, options = {}) => {
-	const deviceProfile = options.deviceProfile || await getJellyfinDeviceProfile();
-	const capabilities = await getDeviceCapabilities();
+	const passthroughSettings = await getPlaybackAudioSettings(options);
+	const profileOptions = {...options, passthroughSettings};
+	const deviceProfile = options.deviceProfile || await getJellyfinDeviceProfile(profileOptions);
+	const capabilities = await getDeviceCapabilities(profileOptions);
 
 	// Cross-server: use item's server if available
 	const api = options.item ? getApiForItem(options.item) : jellyfinApi.api;
@@ -381,7 +409,7 @@ export const getPlaybackInfo = async (itemId, options = {}) => {
 	}
 	/* eslint-enable no-shadow */
 
-	let mediaSource = selectMediaSource(playbackInfo.MediaSources, capabilities, options);
+	let mediaSource = selectMediaSource(playbackInfo.MediaSources, capabilities, options, passthroughSettings);
 
 	// Auto-select a compatible audio stream to avoid unnecessary transcoding
 	let audioStreamIndex = options.audioStreamIndex;
@@ -391,10 +419,10 @@ export const getPlaybackInfo = async (itemId, options = {}) => {
 		);
 		const defaultCodec = (defaultAudioStream?.Codec || '').toLowerCase();
 		const sourceContainer = (mediaSource.Container || '').toLowerCase();
-		const supportedAudio = getSupportedAudioCodecs(capabilities, sourceContainer);
+		const supportedAudio = getSupportedAudioCodecs(capabilities, sourceContainer, passthroughSettings);
 
 		if (defaultCodec && !supportedAudio.includes(defaultCodec)) {
-			const compatibleIndex = findCompatibleAudioStreamIndex(mediaSource, capabilities);
+			const compatibleIndex = findCompatibleAudioStreamIndex(mediaSource, capabilities, passthroughSettings);
 			if (compatibleIndex >= 0) {
 				console.log(`[playback] Default audio track ${mediaSource.DefaultAudioStreamIndex} (${defaultCodec}) unsupported, auto-selecting compatible track ${compatibleIndex}`);
 				// Re-request playback info with the compatible audio stream so the server
@@ -412,10 +440,10 @@ export const getPlaybackInfo = async (itemId, options = {}) => {
 					MediaSourceId: options.mediaSourceId || mediaSource.Id
 				});
 				if (retryInfo.MediaSources?.length) {
-					mediaSource = selectMediaSource(retryInfo.MediaSources, capabilities, options);
+					mediaSource = selectMediaSource(retryInfo.MediaSources, capabilities, options, passthroughSettings);
 					audioStreamIndex = compatibleIndex;
 					playbackInfo = retryInfo;
-					console.log(`[playback] Re-requested with audio track ${compatibleIndex}, play method: ${determinePlayMethod(mediaSource, capabilities)}`);
+					console.log(`[playback] Re-requested with audio track ${compatibleIndex}, play method: ${determinePlayMethod(mediaSource, capabilities, options, passthroughSettings)}`);
 				}
 			} else {
 				console.warn('[playback] No compatible audio track found \u2014 server will remux/transcode');
@@ -423,7 +451,7 @@ export const getPlaybackInfo = async (itemId, options = {}) => {
 		}
 	}
 
-	let playMethod = determinePlayMethod(mediaSource, capabilities, options);
+	let playMethod = determinePlayMethod(mediaSource, capabilities, options, passthroughSettings);
 
 	// Log video stream info including HDR type
 	const videoStream = mediaSource.MediaStreams?.find(s => s.Type === 'Video');
@@ -937,6 +965,14 @@ class PlaybackHealthMonitor {
 		this.bufferEvents = [];
 		this.lastProgressTime = Date.now();
 		this.isHealthy = true;
+		this.isPaused = false;
+	}
+
+	setPaused(paused) {
+		this.isPaused = paused;
+		if (paused) {
+			this.lastProgressTime = Date.now();
+		}
 	}
 
 	recordBuffer() {
@@ -961,6 +997,9 @@ class PlaybackHealthMonitor {
 	}
 
 	checkHealth() {
+		if (this.isPaused) {
+			return true;
+		}
 		if (Date.now() - this.lastProgressTime > 30000) {
 			this.isHealthy = false;
 		}

--- a/packages/app/src/services/video.js
+++ b/packages/app/src/services/video.js
@@ -25,6 +25,7 @@ export const getPlayMethod = (...args) => impl.getPlayMethod(...args);
 export const getMimeType = (...args) => impl.getMimeType(...args);
 export const findCompatibleAudioStreamIndex = (...args) => impl.findCompatibleAudioStreamIndex(...args);
 export const getSupportedAudioCodecs = (...args) => impl.getSupportedAudioCodecs(...args);
+export const isAudioStreamPlayable = (...args) => impl.isAudioStreamPlayable(...args);
 export const setDisplayWindow = (...args) => impl.setDisplayWindow(...args);
 export const registerAppStateObserver = (...args) => impl.registerAppStateObserver(...args);
 export const keepScreenOn = (...args) => impl.keepScreenOn(...args);

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -724,17 +724,41 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				}
 
 				// === Start AVPlay ===
+				console.log('[Player] avplayOpen URL:', result.url);
+				console.log('[Player] playMethod:', result.playMethod, 'mimeType:', result.mimeType, 'container:', result.mediaSource?.Container, 'transcodingContainer:', result.mediaSource?.TranscodingContainer);
 				avplayOpen(result.url);
 				applyDisplayWindow();
 
+				// Samsung AVPlay rejects some Jellyfin transcode endpoints with the
+				// default system User-Agent;
+				// PLAYER_ERROR_CONNECTION_FAILED on Tizen 6+ (i think). USER_AGENT first, USERAGENT fallback for older firmwares.
+				try {
+					avplaySetStreamingProperty('USER_AGENT', 'JellyfinTizenClient');
+				} catch {
+					try { avplaySetStreamingProperty('USERAGENT', 'JellyfinTizenClient'); } catch { /* ignore */ }
+				}
+
+				const videoStream = result.mediaSource?.MediaStreams?.find((s) => s.Type === 'Video');
+				const sourceWidth = videoStream?.Width || 0;
+				const sourceBitrate = result.mediaSource?.Bitrate || 0;
+				const is4K = sourceWidth > 1920 || sourceBitrate > 20000000;
+				const isTranscode = result.playMethod === 'Transcode';
+
+				if (isTranscode && is4K) {
+					try { avplaySetStreamingProperty('SET_MODE_4K', 'TRUE'); } catch { /* ignore */ }
+				}
+
 				if (isLiveTV || result.url.includes('.m3u8')) {
-					// Made birate buffer more dynamic
-					let adaptiveInfo = 'FIXED_MAX_RESOLUTION=1920x1080';
+					const maxRes = is4K ? '3840x2160' : '1920x1080';
+					const props = [
+						`FIXED_MAX_RESOLUTION=${maxRes}`,
+						'STARTBITRATE=HIGHEST',
+						'USER_AGENT=JellyfinTizenClient'
+					];
 					if (typeof effectiveBitrate !== 'undefined' && effectiveBitrate != null) {
-						// AVPlay expects bitrate in bps
-						adaptiveInfo += `;FIXED_MAX_BITRATE=${effectiveBitrate}`;
+						props.push(`FIXED_MAX_BITRATE=${effectiveBitrate}`);
 					}
-					avplaySetStreamingProperty('ADAPTIVE_INFO', adaptiveInfo);
+					avplaySetStreamingProperty('ADAPTIVE_INFO', props.join('|'));
 				}
 
 				avplaySetListener({
@@ -771,15 +795,31 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 					runTimeRef.current = Math.floor(durationMs * 10000);
 				}
 
-				// Seek to start position if resuming
+				// Seek to start position if resuming. For HLS-transcode we defer the
+				// seek until AFTER play() has started — calling seekTo() in the READY
+				// state on a fresh HLS session yields PLAYER_ERROR_SEEK_FAILED.
+				const isHlsTranscode = result.playMethod === playback.PlayMethod.Transcode && result.url?.includes('.m3u8');
+				let deferredSeekMs = 0;
 				if (!isLiveTV && startPosition > 0) {
 					const seekMs = Math.floor(startPosition / 10000);
-					await avplaySeek(seekMs);
+					if (isHlsTranscode) {
+						deferredSeekMs = seekMs;
+					} else {
+						await avplaySeek(seekMs);
+					}
 				}
 
 				// Play - must be called BEFORE setSelectTrack, which requires PLAYING or PAUSED state
 				avplayPlay();
 				setIsPaused(false);
+
+				if (deferredSeekMs > 0) {
+					setTimeout(() => {
+						avplaySeek(deferredSeekMs).catch((e) => {
+							console.warn('[Player] Deferred HLS resume seek failed:', e?.message || e);
+						});
+					}, 1500);
+				}
 
 				// Apply pending track selections (AVPlay must be in PLAYING/PAUSED state)
 				const trackInfo = (pendingAudioIndex != null || pendingSubAction) ? avplayGetTracks() : [];
@@ -914,7 +954,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			pendingSeekMsRef.current = null;
 		};
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [item, resume, selectedQuality, settings.maxBitrate, settings.preferTranscode, settings.forceDirectPlay, settings.subtitleMode, settings.introAction, settings.outroAction, applyDisplayWindow]);
+	}, [item, resume, selectedQuality, settings.maxBitrate, settings.preferTranscode, settings.forceDirectPlay, settings.subtitleMode, settings.introAction, settings.outroAction]);
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return () => {};

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -350,6 +350,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			onbufferingcomplete: () => { setIsBuffering(false); },
 			onstreamcompleted: () => { handleEndedCallbackRef.current?.(); },
 			onerror: (eventType) => {
+				if (isPaused || avplayGetState() === 'PAUSED') return;
 				console.error('[Player] AVPlay error:', eventType);
 				handleErrorCallbackRef.current?.();
 			},
@@ -383,7 +384,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 		// Start time update polling
 		startTimeUpdatePolling();
-	}, [startTimeUpdatePolling, stopTimeUpdatePolling, handleSubtitleChange, applyDisplayWindow]);
+	}, [startTimeUpdatePolling, stopTimeUpdatePolling, handleSubtitleChange, applyDisplayWindow, isPaused]);
 
 	// ==============================
 	// Initialization
@@ -727,7 +728,13 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				applyDisplayWindow();
 
 				if (isLiveTV || result.url.includes('.m3u8')) {
-					avplaySetStreamingProperty('ADAPTIVE_INFO', 'FIXED_MAX_RESOLUTION=1920x1080');
+					// Made birate buffer more dynamic
+					let adaptiveInfo = 'FIXED_MAX_RESOLUTION=1920x1080';
+					if (typeof effectiveBitrate !== 'undefined' && effectiveBitrate != null) {
+						// AVPlay expects bitrate in bps
+						adaptiveInfo += `;FIXED_MAX_BITRATE=${effectiveBitrate}`;
+					}
+					avplaySetStreamingProperty('ADAPTIVE_INFO', adaptiveInfo);
 				}
 
 				avplaySetListener({
@@ -1189,6 +1196,8 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 		if (state === 'PLAYING') {
 			avplayPause();
 			setIsPaused(true);
+			// Pause bug where the playe would thro erros when paused for longer
+			healthMonitorRef.current?.setPaused(true);
 			playback.reportProgress(positionRef.current, { isPaused: true, eventName: 'pause' });
 		} else if (state === 'PAUSED' || state === 'READY') {
 			const rewind = settings.unpauseRewind || 0;
@@ -1199,6 +1208,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			}
 			avplayPlay();
 			setIsPaused(false);
+			healthMonitorRef.current?.setPaused(false);
 			playback.reportProgress(positionRef.current, { isPaused: false, eventName: 'unpause' });
 		}
 	}, [settings.unpauseRewind, isInGroup]);

--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -1297,6 +1297,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 	const handlePlay = useCallback(() => {
 		setIsPaused(false);
+		healthMonitorRef.current?.setPaused(false);
 		if (!hasReportedStartRef.current) {
 			hasReportedStartRef.current = true;
 			playback.reportStart(positionRef.current);
@@ -1314,6 +1315,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 
 	const handlePause = useCallback(() => {
 		setIsPaused(true);
+		healthMonitorRef.current?.setPaused(true);
 		playback.reportProgress(positionRef.current, { isPaused: true, eventName: 'pause' });
 	}, []);
 
@@ -1405,6 +1407,11 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 	}, [onEnded, onPlayNext, nextEpisode, hasNextTrack, audioPlaylist, audioPlaylistIndex, shuffleMode, repeatMode]);
 
 	const handleError = useCallback(async () => {
+		if (isPaused || videoRef.current?.paused) {
+			console.log('[Player] Ignoring error while paused');
+			return;
+		}
+
 		// Ignore errors fired during cleanup (SDR reset video triggers error code 4)
 		if (isCleaningUpRef.current) {
 			console.log('[Player] Ignoring error during cleanup');
@@ -1547,7 +1554,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 		} finally {
 			isHandlingErrorRef.current = false;
 		}
-	}, [hasTriedTranscode, playMethod, item, selectedQuality, settings.maxBitrate, settings.stereoUpmixEnabled, mediaSourceId]);
+	}, [hasTriedTranscode, playMethod, item, selectedQuality, settings.maxBitrate, settings.stereoUpmixEnabled, mediaSourceId, isPaused]);
 
 	useEffect(() => {
 		handlersRef.current = {
@@ -1597,8 +1604,10 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 					videoRef.current.currentTime = newTime;
 				}
 				videoRef.current.play();
+				healthMonitorRef.current?.setPaused(false);
 			} else {
 				videoRef.current.pause();
+				healthMonitorRef.current?.setPaused(true);
 			}
 		}
 	}, [isPaused, settings.unpauseRewind, isInGroup]);

--- a/packages/app/src/views/Settings/Settings.js
+++ b/packages/app/src/views/Settings/Settings.js
@@ -859,8 +859,10 @@ const Settings = ({ onBack, onLibrariesChanged, panelMode }) => {
 			{renderMissingItem('audio-night-mode', $L('Audio Night Mode'), undefined, 'light')}
 			{renderMissingItem('default-audio-language', $L('Default Audio Language'), undefined, 'language')}
 			{renderMissingItem('audio-behavior', $L('Audio Behavior'), undefined, 'sound')}
-			{renderMissingItem('ac3-passthrough', $L('AC3 Passthrough'), undefined, 'speaker')}
-			{renderMissingItem('truehd-support', $L('TrueHD Support'), undefined, 'speaker')}
+			{renderToggleItem('passthroughEnabled', $L('Audio Passthrough'), $L('Enable advanced bitstream passthrough for external audio devices'), 'speaker')}
+			{renderToggleItem('ac3Passthrough', $L('AC3 Passthrough'), $L('Allow Dolby Digital passthrough when available'), 'speaker')}
+			{renderToggleItem('eac3Passthrough', $L('E-AC3 Passthrough'), $L('Allow Dolby Digital Plus passthrough when available'), 'speaker')}
+			{renderToggleItem('truehdPassthrough', $L('TrueHD Passthrough'), $L('Allow Dolby TrueHD passthrough when available'), 'speaker')}
 		</>
 	);
 

--- a/packages/platform-tizen/src/deviceProfile.js
+++ b/packages/platform-tizen/src/deviceProfile.js
@@ -15,6 +15,74 @@
 
 let cachedCapabilities = null;
 
+const DEFAULT_PASSTHROUGH_SETTINGS = {
+	passthroughEnabled: true,
+	ac3Passthrough: true,
+	eac3Passthrough: true,
+	dtsPassthrough: true,
+	dtshdPassthrough: true,
+	truehdPassthrough: true
+};
+
+const resolvePassthroughSettings = (options = {}) => ({
+	...DEFAULT_PASSTHROUGH_SETTINGS,
+	...(options?.passthroughSettings || {})
+});
+
+const probeTizenAudioCodecSupport = () => {
+	const support = {
+		ac3: testAc3Support(),
+		eac3: testEac3Support(),
+		truehd: testTruehdSupport(),
+		dts: testDtsSupport(),
+		dtshd: false
+	};
+
+	if (typeof webapis === 'undefined' || !webapis.systeminfo || typeof webapis.systeminfo.isSupportedAudioCodec !== 'function') {
+		return support;
+	}
+
+	const codecAliases = {
+		ac3: ['AC3'],
+		eac3: ['E-AC3'],
+		truehd: ['TrueHD'],
+		dts: ['DTS'],
+		dtshd: ['DTS-HD', 'DTSHD']
+	};
+
+	for (const [key, aliases] of Object.entries(codecAliases)) {
+		for (const alias of aliases) {
+			try {
+				if (webapis.systeminfo.isSupportedAudioCodec(alias) === true) {
+					support[key] = true;
+					break;
+				}
+			} catch (e) {
+				// Ignore unsupported alias errors and continue probing because yeet haw
+			}
+		}
+	}
+
+	if (support.dtshd) support.dts = true;
+
+	console.log('[deviceProfile] Tizen audio codec probe:', support);
+	return support;
+};
+
+const applyPassthroughSettings = (caps, options = {}) => {
+	const prefs = resolvePassthroughSettings(options);
+	const passthroughAllowed = prefs.passthroughEnabled;
+
+	return {
+		...caps,
+		ac3: !!caps.ac3 && !!prefs.ac3Passthrough,
+		eac3: !!caps.eac3 && !!prefs.eac3Passthrough,
+		truehd: !!caps.truehd && passthroughAllowed && !!prefs.truehdPassthrough,
+		dts: !!caps.dts && passthroughAllowed && !!prefs.dtsPassthrough,
+		dtshd: !!caps.dtshd && passthroughAllowed && !!prefs.dtshdPassthrough
+	};
+};
+
 export const clearCapabilitiesCache = () => {
 	cachedCapabilities = null;
 };
@@ -336,6 +404,8 @@ export const getDeviceCapabilities = async () => {
 		}
 	}
 
+	const audioProbe = probeTizenAudioCodecSupport();
+
 	cachedCapabilities = {
 		modelName,
 		modelNameAscii: modelName,
@@ -358,16 +428,14 @@ export const getDeviceCapabilities = async () => {
 		hdr10Plus: hdr10 && tizenVersion >= 5, // HDR10+ on 2019+ premium models
 		hlg: hdr10 && tizenVersion >= 4, // HLG on 2018+ HDR-capable models
 		dolbyVision,
-
-		// Audio capabilities - per Samsung documentation
 		// Samsung docs: "DD+: 5.1 channel supported" for all years
 		// No documentation supports 7.1/8-channel audio on Tizen TVs
-		dolbyAtmos: false, // Not documented in Samsung specs
-		dts: testDtsSupport(), // false - Samsung explicitly says not supported
-		ac3: testAc3Support(),
-		eac3: testEac3Support(),
-		truehd: testTruehdSupport(), // false - not in Samsung specs
-		dtshd: false,
+		dolbyAtmos: true, // MOK turned it on. Why? Because 7.1 comes sometimes iwth atmos and this stopps it from letting it play
+		dts: audioProbe.dts,
+		ac3: audioProbe.ac3,
+		eac3: audioProbe.eac3,
+		truehd: audioProbe.truehd,
+		dtshd: audioProbe.dtshd,
 		opus: true,
 
 		// Video codec capabilities
@@ -387,7 +455,8 @@ export const getDeviceCapabilities = async () => {
 };
 
 export const getJellyfinDeviceProfile = async () => {
-	const caps = await getDeviceCapabilities();
+	const baseCaps = await getDeviceCapabilities();
+	const caps = applyPassthroughSettings(baseCaps, arguments[0]);
 
 	// --- Video codecs per Samsung spec tables ---
 	// Samsung specs officially list VP9/AV1 as WebM-only, but in practice

--- a/packages/platform-tizen/src/deviceProfile.js
+++ b/packages/platform-tizen/src/deviceProfile.js
@@ -487,10 +487,9 @@ export const getJellyfinDeviceProfile = async () => {
 	if (caps.eac3) audioCodecs.push('eac3');
 	if (caps.opus) audioCodecs.push('opus');
 	if (caps.truehd) audioCodecs.push('truehd');
-	if (caps.dts) audioCodecs.push('dca', 'dts');
-	if (caps.dts && caps.dtshd) audioCodecs.push('dts-hd', 'dtshd');
-	// DTS intentionally excluded - Samsung docs: "DTS Audio codec is not supported"
 	// TrueHD intentionally excluded - not in Samsung specifications
+	// TrueHD+Atmos is filtered out at the codec-profile level below.
+	// I might change it in the future so that pure TRueHD without atmos can be played as this is possible, but it was currently easier to just trancode it and yeeeeeeeeet
 
 	// General video containers per Samsung spec tables (for H.264/HEVC)
 	// Note: HEVC only works in MKV/MP4/TS per Samsung docs
@@ -549,11 +548,30 @@ export const getJellyfinDeviceProfile = async () => {
 		});
 	}
 
+	// fMP4 HLS is listed as first, so Jellyfin prefers it. fMP4 is required to allow
+	// AV1 video passthrough (TS container does not support AV1) — without it the
+	// server would re-encode AV1 → HEVC. With fMP4 + AV1 listed, the server emits
+	// `-c:v copy -c:a eac3` for AV1+TrueHD/DTS sources
+	// TS+HLS is kept as a fallback for HEVC/H.264 sources on firmwares
+	// that may have fMP4 quirks.
+	const v1AndH26x = caps.av1 ? 'av1,hevc,h264' : 'hevc,h264';
+	const tsAudio = caps.eac3 ? 'eac3,ac3,aac' : (caps.ac3 ? 'ac3,aac' : 'aac');
 	const transcodingProfiles = [
+		{
+			Container: 'mp4',
+			Type: 'Video',
+			AudioCodec: tsAudio,
+			VideoCodec: v1AndH26x,
+			Context: 'Streaming',
+			Protocol: 'hls',
+			MaxAudioChannels: maxAudioChannels,
+			MinSegments: '1',
+			SegmentLength: '3'
+		},
 		{
 			Container: 'ts',
 			Type: 'Video',
-			AudioCodec: caps.ac3 ? 'aac,ac3,eac3' : 'aac',
+			AudioCodec: tsAudio,
 			VideoCodec: caps.hevc ? 'hevc,h264' : 'h264',
 			Context: 'Streaming',
 			Protocol: 'hls',
@@ -561,13 +579,6 @@ export const getJellyfinDeviceProfile = async () => {
 			MinSegments: '1',
 			SegmentLength: '3',
 			BreakOnNonKeyFrames: true
-		},
-		{
-			Container: 'mp4',
-			Type: 'Video',
-			AudioCodec: 'aac,ac3',
-			VideoCodec: 'h264',
-			Context: 'Static'
 		},
 		{
 			Container: 'mp3',
@@ -659,6 +670,20 @@ export const getJellyfinDeviceProfile = async () => {
 			]
 		}
 	];
+
+	// Force any kind of DTS to be transcoded to E-AC3 
+	codecProfiles.push({
+		Type: 'VideoAudio',
+		Codec: 'dts,dca,dts-hd,dtshd,dts-ma,dtsma,dts-x,dtsx',
+		Conditions: [{ Condition: 'Equals', Property: 'AudioChannels', Value: '0', IsRequired: true }]
+	});
+
+	// Force a transcode to all TrueHD/MLP. Samsung AVPlay cannot decode TrueHD (with or without Atmos) reliably
+	codecProfiles.push({
+		Type: 'VideoAudio',
+		Codec: 'truehd,mlp',
+		Conditions: [{ Condition: 'Equals', Property: 'AudioChannels', Value: '0', IsRequired: true }]
+	});
 
 	if (caps.av1) {
 		codecProfiles.push({

--- a/packages/platform-tizen/src/video.js
+++ b/packages/platform-tizen/src/video.js
@@ -6,6 +6,20 @@ import {detectTizenVersion as _detectTizenVersion} from './deviceProfile';
 
 let isAVPlayAvailable = false;
 
+const DEFAULT_PASSTHROUGH_SETTINGS = {
+	passthroughEnabled: true,
+	ac3Passthrough: true,
+	eac3Passthrough: true,
+	dtsPassthrough: true,
+	dtshdPassthrough: true,
+	truehdPassthrough: true
+};
+
+const resolvePassthroughSettings = (options = {}) => ({
+	...DEFAULT_PASSTHROUGH_SETTINGS,
+	...(options || {})
+});
+
 export const isTizen = () => {
 	if (typeof window === 'undefined') return false;
 	if (typeof window.tizen !== 'undefined') return true;
@@ -117,15 +131,15 @@ export const getMediaCapabilities = async () => {
 /**
  * Get the list of audio codecs supported by the TV hardware.
  */
-export const getSupportedAudioCodecs = (capabilities) => {
+export const getSupportedAudioCodecs = (capabilities, _container = '', passthroughOptions = {}) => {
+	const passthrough = resolvePassthroughSettings(passthroughOptions);
+	const passthroughAllowed = passthrough.passthroughEnabled;
 	const codecs = ['aac', 'mp3', 'flac', 'vorbis', 'pcm', 'wav'];
-	if (capabilities.ac3) codecs.push('ac3');
-	if (capabilities.eac3) codecs.push('eac3');
+	if (capabilities.ac3 && passthrough.ac3Passthrough) codecs.push('ac3');
+	if (capabilities.eac3 && passthrough.eac3Passthrough) codecs.push('eac3');
 	if (capabilities.opus) codecs.push('opus');
-	if (capabilities.dts) codecs.push('dts', 'dca');
-	if (capabilities.dts && capabilities.dtshd) codecs.push('dts-hd', 'dtshd');
+	if (capabilities.truehd && passthroughAllowed && passthrough.truehdPassthrough) codecs.push('truehd', 'mlp');
 	// DTS: Samsung explicitly states not supported on any TV (2018-2025)
-	// TrueHD: Not documented in Samsung specifications
 	return codecs;
 };
 
@@ -134,9 +148,9 @@ export const getSupportedAudioCodecs = (capabilities) => {
  * Returns the index of the first audio stream whose codec is supported,
  * or -1 if no compatible audio stream exists.
  */
-export const findCompatibleAudioStreamIndex = (mediaSource, capabilities) => {
+export const findCompatibleAudioStreamIndex = (mediaSource, capabilities, passthroughOptions = {}) => {
 	if (!mediaSource?.MediaStreams) return -1;
-	const supported = getSupportedAudioCodecs(capabilities);
+	const supported = getSupportedAudioCodecs(capabilities, mediaSource.Container, passthroughOptions);
 	const audioStreams = mediaSource.MediaStreams.filter(s => s.Type === 'Audio');
 	for (const stream of audioStreams) {
 		const codec = (stream.Codec || '').toLowerCase();
@@ -147,7 +161,7 @@ export const findCompatibleAudioStreamIndex = (mediaSource, capabilities) => {
 	return -1;
 };
 
-export const getPlayMethod = (mediaSource, capabilities) => {
+export const getPlayMethod = (mediaSource, capabilities, _options = {}, passthroughOptions = {}) => {
 	if (!mediaSource) return 'Transcode';
 
 	const container = (mediaSource.Container || '').toLowerCase();
@@ -160,8 +174,7 @@ export const getPlayMethod = (mediaSource, capabilities) => {
 	if (capabilities.vp9) supportedVideoCodecs.push('vp9');
 	if (capabilities.dolbyVision) supportedVideoCodecs.push('dvhe', 'dvh1');
 
-	// Audio codecs per Samsung spec tables — DTS and TrueHD intentionally excluded
-	const supportedAudioCodecs = getSupportedAudioCodecs(capabilities);
+	const supportedAudioCodecs = getSupportedAudioCodecs(capabilities, container, passthroughOptions);
 
 	// Check if ANY audio stream is compatible (not just the first/default one).
 	// Samsung TVs can select audio tracks from containers like MKV/MP4.

--- a/packages/platform-tizen/src/video.js
+++ b/packages/platform-tizen/src/video.js
@@ -143,6 +143,28 @@ export const getSupportedAudioCodecs = (capabilities, _container = '', passthrou
 	return codecs;
 };
 
+const DTS_FAMILY_CODECS = ['dts', 'dca', 'dts-hd', 'dtshd', 'dts-ma', 'dtsma', 'dts-x', 'dtsx'];
+
+const streamHasAtmos = (stream) => {
+	if (!stream) return false;
+	const fields = [stream.Profile, stream.Title, stream.DisplayTitle, stream.ChannelLayout];
+	if (fields.some(v => typeof v === 'string' && /atmos/i.test(v))) return true;
+	// legacy atmos detection, i might come back later for direct stream of atmos (In love MOK)
+	const codec = (stream.Codec || '').toLowerCase();
+	if ((codec === 'truehd' || codec === 'mlp') && (stream.Channels || 0) > 8) return true;
+	return false;
+};
+
+export const isAudioStreamPlayable = (stream, capabilities, passthroughOptions = {}) => {
+	if (!stream) return false;
+	const codec = (stream.Codec || '').toLowerCase();
+	if (!codec) return true;
+	if (DTS_FAMILY_CODECS.includes(codec)) return false;
+	if ((codec === 'truehd' || codec === 'mlp') && streamHasAtmos(stream)) return false;
+	const supported = getSupportedAudioCodecs(capabilities, '', passthroughOptions);
+	return supported.includes(codec);
+};
+
 /**
  * Find the first compatible audio stream index for a media source.
  * Returns the index of the first audio stream whose codec is supported,
@@ -150,11 +172,9 @@ export const getSupportedAudioCodecs = (capabilities, _container = '', passthrou
  */
 export const findCompatibleAudioStreamIndex = (mediaSource, capabilities, passthroughOptions = {}) => {
 	if (!mediaSource?.MediaStreams) return -1;
-	const supported = getSupportedAudioCodecs(capabilities, mediaSource.Container, passthroughOptions);
 	const audioStreams = mediaSource.MediaStreams.filter(s => s.Type === 'Audio');
 	for (const stream of audioStreams) {
-		const codec = (stream.Codec || '').toLowerCase();
-		if (!codec || supported.includes(codec)) {
+		if (isAudioStreamPlayable(stream, capabilities, passthroughOptions)) {
 			return stream.Index;
 		}
 	}
@@ -176,14 +196,23 @@ export const getPlayMethod = (mediaSource, capabilities, _options = {}, passthro
 
 	const supportedAudioCodecs = getSupportedAudioCodecs(capabilities, container, passthroughOptions);
 
-	// Check if ANY audio stream is compatible (not just the first/default one).
-	// Samsung TVs can select audio tracks from containers like MKV/MP4.
-	// A file with DTS primary + AC3 secondary should still DirectPlay.
+	// Check if ANY audio stream is compatible (informational only — see below).
 	const audioStreams = mediaSource.MediaStreams?.filter(s => s.Type === 'Audio') || [];
-	const hasCompatibleAudio = audioStreams.length === 0 || audioStreams.some(s => {
-		const codec = (s.Codec || '').toLowerCase();
-		return !codec || supportedAudioCodecs.includes(codec);
-	});
+	const hasCompatibleAudio = audioStreams.length === 0 || audioStreams.some(s =>
+		isAudioStreamPlayable(s, capabilities, passthroughOptions)
+	);
+
+	// AVPlay always decodes the file's default audio track and ignores the
+	// AudioStreamIndex hint passed in the stream URL. That means a multi-track
+	// file with TrueHD/DTS as the default and AC3 as a secondary cannot
+	// DirectPlay even though an alternate compatible track exists — AVPlay
+	// will still try to decode the default and fail with "codec not supported".
+	// So DirectPlay/DirectStream on the DEFAULT track being playable, and
+	// force audio remux whenever the default is unplayable.
+	const defaultStream = audioStreams.find(s => s.Index === mediaSource.DefaultAudioStreamIndex) || audioStreams[0];
+	const defaultPlayable = !defaultStream || isAudioStreamPlayable(defaultStream, capabilities, passthroughOptions);
+	const hasAlternatePlayable = audioStreams.some(s => s !== defaultStream && isAudioStreamPlayable(s, capabilities, passthroughOptions));
+	const needsAudioRemux = !defaultPlayable && audioStreams.length > 0;
 
 	const supportedContainers = ['mp4', 'm4v', 'mov', 'ts', 'mpegts', 'mkv', 'matroska', 'webm', 'avi',
 		// Audio containers
@@ -191,7 +220,7 @@ export const getPlayMethod = (mediaSource, capabilities, _options = {}, passthro
 	if (capabilities.nativeHls) supportedContainers.push('m3u8');
 
 	const videoOk = !videoCodec || supportedVideoCodecs.includes(videoCodec);
-	const audioOk = hasCompatibleAudio;
+	const audioOk = defaultPlayable;
 	const containerOk = !container || supportedContainers.includes(container);
 
 	// Samsung docs: "HEVC: Supported only for MKV/MP4/TS containers"
@@ -246,6 +275,12 @@ export const getPlayMethod = (mediaSource, capabilities, _options = {}, passthro
 	});
 
 	const codecContainerOk = hevcContainerOk && vp9ContainerOk && av1ContainerOk;
+
+	if (needsAudioRemux) {
+		// Default audio is unplayableso request a force remux
+		console.log('[tizenVideo] Default audio unplayable (TrueHD+Atmos/DTS) with no alternate \u2014 forcing Transcode for audio remux');
+		return 'Transcode';
+	}
 
 	if (mediaSource.SupportsDirectPlay && videoOk && audioOk && containerOk && hdrOk && codecContainerOk) {
 		return 'DirectPlay';
@@ -725,6 +760,7 @@ export default {
 	getMimeType,
 	getSupportedAudioCodecs,
 	findCompatibleAudioStreamIndex,
+	isAudioStreamPlayable,
 	setDisplayWindow,
 	registerAppStateObserver,
 	keepScreenOn,

--- a/packages/platform-webos/src/deviceProfile.js
+++ b/packages/platform-webos/src/deviceProfile.js
@@ -2,6 +2,58 @@
 
 let cachedCapabilities = null;
 
+const DEFAULT_PASSTHROUGH_SETTINGS = {
+	passthroughEnabled: true,
+	ac3Passthrough: true,
+	eac3Passthrough: true,
+	dtsPassthrough: true,
+	dtshdPassthrough: true,
+	truehdPassthrough: true
+};
+
+const resolvePassthroughSettings = (options = {}) => ({
+	...DEFAULT_PASSTHROUGH_SETTINGS,
+	...(options?.passthroughSettings || {})
+});
+
+const emptyDtsSupport = {mkv: false, mp4: false, ts: false, avi: false};
+
+const isExternalAudioPath = (audioStatus = {}) => {
+	const payload = JSON.stringify(audioStatus || {}).toLowerCase();
+	return /(earc|arc|hdmi|receiver|external|spdif|optical)/.test(payload);
+};
+
+const getAudioOutputStatus = async () => {
+	try {
+		const LS2Request = (await import('@enact/webos/LS2Request')).default;
+		return await new Promise((resolve) => {
+			new LS2Request().send({
+				service: 'luna://com.webos.service.avoutput',
+				method: 'audio/getStatus',
+				onSuccess: resolve,
+				onFailure: () => resolve({})
+			});
+		});
+	} catch (e) {
+		return {};
+	}
+};
+
+const applyPassthroughSettings = (caps, options = {}) => {
+	const prefs = resolvePassthroughSettings(options);
+	const passthroughAllowed = prefs.passthroughEnabled;
+	const dtsSupport = passthroughAllowed && prefs.dtsPassthrough ? (caps.dts || emptyDtsSupport) : emptyDtsSupport;
+
+	return {
+		...caps,
+		ac3: !!caps.ac3 && !!prefs.ac3Passthrough,
+		eac3: !!caps.eac3 && !!prefs.eac3Passthrough,
+		truehd: !!caps.truehd && passthroughAllowed && !!prefs.truehdPassthrough,
+		dts: dtsSupport,
+		dtshd: !!caps.dtshd && passthroughAllowed && !!prefs.dtshdPassthrough
+	};
+};
+
 export const clearCapabilitiesCache = () => {
 	cachedCapabilities = null;
 };
@@ -179,9 +231,13 @@ export const getDeviceCapabilities = async () => {
 
 	// tv.model.edidType is undocumented and may be absent on some firmware.
 	const rawEdidType = cfg['tv.model.edidType'];
+	const audioOutputStatus = await getAudioOutputStatus();
+	const externalAudioPathActive = isExternalAudioPath(audioOutputStatus);
 
-	// Per-container DTS support based on LG documentation + edidType detection
-	const dtsSupport = getDtsContainerSupport(webosVersion, rawEdidType);
+	// This is kind obsolete, need to fix encoding bug first tho
+	const dtsSupport = externalAudioPathActive
+		? {mkv: true, mp4: true, ts: true, avi: false}
+		: getDtsContainerSupport(webosVersion, rawEdidType);
 
 	cachedCapabilities = {
 		modelName: deviceInfoData.modelName || cfg['tv.model.modelname'] || 'Unknown',
@@ -221,9 +277,8 @@ export const getDeviceCapabilities = async () => {
 		dts: dtsSupport,
 		ac3: testAc3Support(),
 		eac3: true,
-		// webOS can only passthrough TrueHD/DTS-HD to an AV receiver, not decode internally
-		truehd: false,
-		dtshd: false,
+		truehd: externalAudioPathActive,
+		dtshd: externalAudioPathActive && !!(dtsSupport.mkv || dtsSupport.mp4 || dtsSupport.ts),
 		opus: webosVersion >= 6,
 
 		hevc: testHevcSupport(null, webosVersion),
@@ -237,6 +292,8 @@ export const getDeviceCapabilities = async () => {
 		nativeHlsFmp4: webosVersion >= 5,
 		hlsAc3: webosVersion >= 5,
 		hlsByteRange: webosVersion >= 4,
+		audioOutputStatus,
+		externalAudioPathActive,
 
 		lunaConfig: cfg,
 		ddrSize: cfg['tv.hw.ddrSize'] || 0
@@ -534,14 +591,15 @@ const buildDirectPlayProfiles = (caps) => {
 	return profiles;
 };
 
-export const getJellyfinDeviceProfile = async () => {
-	const caps = await getDeviceCapabilities();
+export const getJellyfinDeviceProfile = async (options = {}) => {
+	const baseCaps = await getDeviceCapabilities();
+	const caps = applyPassthroughSettings(baseCaps, options);
 
 	const videoRangeTypes = buildVideoRangeTypes(caps);
 	const directPlayProfiles = buildDirectPlayProfiles(caps);
 
 	const maxStreamingBitrate = 120_000_000;
-	const maxAudioChannels = caps.dolbyAtmos ? '8' : '6';
+	const maxAudioChannels = caps.dolbyAtmos || caps.truehd || caps.dtshd ? '8' : '6';
 
 	// fMP4 preserves DV RPU metadata; MPEG-TS strips it. Use fMP4 on webOS 5+.
 	const hlsContainer = caps.nativeHlsFmp4 ? 'mp4' : 'ts';
@@ -803,8 +861,8 @@ export const getJellyfinDeviceProfile = async () => {
 };
 
 /** H.264+AAC-only profile for hls.js/MSE fallback when native HEVC decoding fails. */
-export const getH264FallbackProfile = async () => {
-	const profile = await getJellyfinDeviceProfile();
+export const getH264FallbackProfile = async (options = {}) => {
+	const profile = await getJellyfinDeviceProfile(options);
 
 	profile.TranscodingProfiles = [
 		{

--- a/packages/platform-webos/src/video.js
+++ b/packages/platform-webos/src/video.js
@@ -5,6 +5,20 @@
 let lunaClient = null;
 let isLunaAvailable = false;
 
+const DEFAULT_PASSTHROUGH_SETTINGS = {
+	passthroughEnabled: true,
+	ac3Passthrough: true,
+	eac3Passthrough: true,
+	dtsPassthrough: true,
+	dtshdPassthrough: true,
+	truehdPassthrough: true
+};
+
+const resolvePassthroughSettings = (options = {}) => ({
+	...DEFAULT_PASSTHROUGH_SETTINGS,
+	...(options || {})
+});
+
 export const isWebOS = () => {
 	if (typeof window === 'undefined') return false;
 	if (typeof window.webOS !== 'undefined') return true;
@@ -55,17 +69,19 @@ const lunaCall = (service, method, parameters = {}) => {
  * @param {string} [container=''] - Container format (e.g., 'mkv', 'mp4'). Empty = no container restriction.
  * @returns {string[]} Array of supported audio codec strings
  */
-export const getSupportedAudioCodecs = (capabilities, container = '') => {
+export const getSupportedAudioCodecs = (capabilities, container = '', passthroughOptions = {}) => {
+	const passthrough = resolvePassthroughSettings(passthroughOptions);
+	const passthroughAllowed = passthrough.passthroughEnabled;
 	const codecs = ['aac', 'mp3', 'mp2', 'mp1', 'flac', 'pcm_s16le', 'pcm_s24le', 'lpcm', 'wav'];
 
-	const ac3Ok = capabilities.ac3;
-	const eac3Ok = capabilities.eac3;
+	const ac3Ok = capabilities.ac3 && passthrough.ac3Passthrough;
+	const eac3Ok = capabilities.eac3 && passthrough.eac3Passthrough;
 
 	if (ac3Ok) codecs.push('ac3', 'dolby');
 	if (eac3Ok) codecs.push('eac3', 'ec3');
 
 	// DTS: per-container support based on webOS version
-	if (capabilities.dts) {
+	if (capabilities.dts && passthroughAllowed && passthrough.dtsPassthrough) {
 		const dtsObj = capabilities.dts;
 		let dtsOk = false;
 		if (!container) {
@@ -81,10 +97,10 @@ export const getSupportedAudioCodecs = (capabilities, container = '') => {
 			dtsOk = !!dtsObj.avi;
 		}
 		if (dtsOk) codecs.push('dts', 'dca');
-		if (dtsOk && capabilities.dtshd) codecs.push('dts-hd', 'dtshd');
+		if (dtsOk && capabilities.dtshd) codecs.push('dts-hd', 'dtshd', 'dtsx');
 	}
 
-	if (capabilities.truehd) codecs.push('truehd', 'mlp');
+	if (capabilities.truehd && passthroughAllowed && passthrough.truehdPassthrough) codecs.push('truehd', 'mlp');
 	if (capabilities.opus) codecs.push('opus');
 	codecs.push('vorbis', 'wma', 'amr', 'amrnb', 'amrwb');
 
@@ -96,10 +112,10 @@ export const getSupportedAudioCodecs = (capabilities, container = '') => {
  * Returns the index of the first audio stream whose codec is supported,
  * or -1 if no compatible audio stream exists.
  */
-export const findCompatibleAudioStreamIndex = (mediaSource, capabilities) => {
+export const findCompatibleAudioStreamIndex = (mediaSource, capabilities, passthroughOptions = {}) => {
 	if (!mediaSource?.MediaStreams) return -1;
 	const container = (mediaSource.Container || '').toLowerCase();
-	const supported = getSupportedAudioCodecs(capabilities, container);
+	const supported = getSupportedAudioCodecs(capabilities, container, passthroughOptions);
 	const audioStreams = mediaSource.MediaStreams.filter(s => s.Type === 'Audio');
 	for (const stream of audioStreams) {
 		const codec = (stream.Codec || '').toLowerCase();
@@ -110,7 +126,7 @@ export const findCompatibleAudioStreamIndex = (mediaSource, capabilities) => {
 	return -1;
 };
 
-export const getPlayMethod = (mediaSource, capabilities, options = {}) => {
+export const getPlayMethod = (mediaSource, capabilities, options = {}, passthroughOptions = {}) => {
 	if (!mediaSource) return 'Transcode';
 
 	const container = (mediaSource.Container || '').toLowerCase();
@@ -137,7 +153,7 @@ export const getPlayMethod = (mediaSource, capabilities, options = {}) => {
 	// dvh1 (DV Profile 8) has an HEVC base layer playable without native DV
 	if (!capabilities.dolbyVision && capabilities.hevc) supportedVideoCodecs.push('dvh1');
 
-	const supportedAudioCodecs = getSupportedAudioCodecs(capabilities, container);
+	const supportedAudioCodecs = getSupportedAudioCodecs(capabilities, container, passthroughOptions);
 	const isAudioOnly = !videoStream && audioStreams.length > 0;
 
 	// Check if ANY audio stream is compatible (not just the default/first one).

--- a/packages/platform-webos/src/video.js
+++ b/packages/platform-webos/src/video.js
@@ -107,6 +107,15 @@ export const getSupportedAudioCodecs = (capabilities, container = '', passthroug
 	return codecs;
 };
 
+// WebOS handles it on its own i think
+export const isAudioStreamPlayable = (stream, capabilities, passthroughOptions = {}) => {
+	if (!stream) return false;
+	const codec = (stream.Codec || '').toLowerCase();
+	if (!codec) return true;
+	const supported = getSupportedAudioCodecs(capabilities, '', passthroughOptions);
+	return supported.includes(codec);
+};
+
 /**
  * Find the first compatible audio stream index for a media source.
  * Returns the index of the first audio stream whose codec is supported,
@@ -114,12 +123,9 @@ export const getSupportedAudioCodecs = (capabilities, container = '', passthroug
  */
 export const findCompatibleAudioStreamIndex = (mediaSource, capabilities, passthroughOptions = {}) => {
 	if (!mediaSource?.MediaStreams) return -1;
-	const container = (mediaSource.Container || '').toLowerCase();
-	const supported = getSupportedAudioCodecs(capabilities, container, passthroughOptions);
 	const audioStreams = mediaSource.MediaStreams.filter(s => s.Type === 'Audio');
 	for (const stream of audioStreams) {
-		const codec = (stream.Codec || '').toLowerCase();
-		if (!codec || supported.includes(codec)) {
+		if (isAudioStreamPlayable(stream, capabilities, passthroughOptions)) {
 			return stream.Index;
 		}
 	}
@@ -601,6 +607,7 @@ export default {
 	getMimeType,
 	getSupportedAudioCodecs,
 	findCompatibleAudioStreamIndex,
+	isAudioStreamPlayable,
 	setDisplayWindow,
 	registerAppStateObserver,
 	keepScreenOn,


### PR DESCRIPTION
# Pull Request

## Summary
TrueHD and DTS will be remuxed in generell can be forced tho, for this TrueHD made workable. TrueHD with atmos will most-likely just don't play audio as the AVPlayer stops pass-trough and converts it in bitsreams. Fixed small bugs that where before present.
Tried Web OS but no testing done.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
#219
#209 
- Related to #

## Type of Change
- [ x] Bug fix
- [x ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- TrueHD and DTS will now in generell remux only the audio container to E-AC3 
- Fixed transcodekiller killing transcode in generell
- Added debugg on tv thats shows the consol without sdb because i hate sdb
- Fixed a loop/race condition that could request remuxes or playback of file sin rare cases multiple times 

## Platform
- [x ] Tizen (Samsung)
- [ x] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [ x] Tested on physical device
- [x ] Manual testing completed
- [x ] Not tested (explain why):
- Tizen fully tested (Tizen 9). 
- WEB OS not tested because i dint have a device and emulator enviroment

### Test Steps
1. Played a TrueHD + Atmos title in av1 4k and hvec
2. collected logs of what happend after pressing play
3. Played a DTS title in 4k av1 
4. collected logs
5. final finishing test -> Tested generell 1080p DTS h265 and av1 file plus normal files sdr 1080p aac/E-Ac3/Opus h264/h265 and av1 files 

## Checklist
- [x ] Code builds successfully
- [ x] Code follows project style and conventions
- [ x] No unnecessary commented-out code
- [? ] No new warnings introduced -> didnt keept a eye on it but shuldnt be
