### PR TITLE
add offset to top of home screen when using topbar

### DIFF
--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -1435,7 +1435,7 @@ const Browse = ({
 
 	return (
 		<div className={css.page}>
-			<div className={`${css.mainContent} ${settings.navbarPosition === 'left' ? css.sidebarOffset : ''}`} ref={mainContentRef}>
+			<div className={`${css.mainContent} ${settings.navbarPosition === 'left' ? css.sidebarOffset : css.topbarOffset}`} ref={mainContentRef}>
 				<BackdropLayer
 					targetUrl={targetBackdropUrl}
 					blurAmount={settings.backdropBlurHome}

--- a/packages/app/src/views/Browse/Browse.module.less
+++ b/packages/app/src/views/Browse/Browse.module.less
@@ -1280,6 +1280,10 @@
 	padding-left: 50px;
 }
 
+.topbarOffset .contentRows {
+	padding-top: 75px;
+}
+
 .sidebarOffset .detailSection {
 	padding-left: 110px;
 }


### PR DESCRIPTION
# Pull Request

## Summary
Similar to how sidebar has a left side offset, I added a top offset if topbar is used. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #234 
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add topbarOffset  css definition to Browse.module.less
- add topbarOffset to Browse.js if navbarPosition != left, instead of leaving it blank
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="3807" height="1802" alt="image" src="https://github.com/user-attachments/assets/bcf10ae4-ffbf-4b0f-8a10-f54208bc3d4c" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
