### PR TITLE
feat: Request SortName for non-ascii alphabetic filtering

### DIFF
--- a/packages/app/src/views/Favorites/Favorites.js
+++ b/packages/app/src/views/Favorites/Favorites.js
@@ -67,7 +67,7 @@ const initialFocusDoneRef = useRef(false);
 const items = useMemo(() => {
 if (!startLetter) return allItems;
 return allItems.filter(item => {
-const name = item.Name || '';
+const name = item.SortName || '';
 const firstChar = name.charAt(0).toUpperCase();
 if (startLetter === '#') return !/[A-Z]/.test(firstChar);
 return firstChar === startLetter;
@@ -123,7 +123,7 @@ SortOrder: sortOption.order,
 StartIndex: startIndex,
 Limit: 150,
 EnableTotalRecordCount: true,
-Fields: 'ProductionYear,ImageTags,OfficialRating,CommunityRating,CriticRating,RunTimeTicks,UserData,SortName'
+Fields: 'SortName,ProductionYear,ImageTags,OfficialRating,CommunityRating,CriticRating,RunTimeTicks,UserData,SortName'
 };
 
 const result = await api.getItems(params);

--- a/packages/app/src/views/Favorites/Favorites.js
+++ b/packages/app/src/views/Favorites/Favorites.js
@@ -123,7 +123,7 @@ SortOrder: sortOption.order,
 StartIndex: startIndex,
 Limit: 150,
 EnableTotalRecordCount: true,
-Fields: 'SortName,ProductionYear,ImageTags,OfficialRating,CommunityRating,CriticRating,RunTimeTicks,UserData,SortName'
+Fields: 'ProductionYear,ImageTags,OfficialRating,CommunityRating,CriticRating,RunTimeTicks,UserData,SortName'
 };
 
 const result = await api.getItems(params);

--- a/packages/app/src/views/Library/Library.js
+++ b/packages/app/src/views/Library/Library.js
@@ -135,7 +135,7 @@ if (!startLetter) {
 return allItems;
 }
 return allItems.filter(item => {
-const name = item.Name || '';
+const name = item.SortName || '';
 const firstChar = name.charAt(0).toUpperCase();
 if (startLetter === '#') {
 return !/[A-Z]/.test(firstChar);
@@ -244,7 +244,7 @@ if (isFolderView) {
 		SortOrder: sortOption.order,
 		Recursive: true,
 		EnableTotalRecordCount: true,
-		Fields: 'ProductionYear,ImageTags,OfficialRating,CommunityRating,CriticRating,RunTimeTicks,ProviderIds,UserData'
+		Fields: 'SortName,ProductionYear,ImageTags,OfficialRating,CommunityRating,CriticRating,RunTimeTicks,ProviderIds,UserData'
 	};
 
 	if (library?.Id) params.ParentId = library.Id;

--- a/packages/app/src/views/Library/Library.js
+++ b/packages/app/src/views/Library/Library.js
@@ -135,7 +135,7 @@ if (!startLetter) {
 return allItems;
 }
 return allItems.filter(item => {
-const name = item.SortName || '';
+const name = item.SortName || item.Name || '';
 const firstChar = name.charAt(0).toUpperCase();
 if (startLetter === '#') {
 return !/[A-Z]/.test(firstChar);


### PR DESCRIPTION
# Pull Request

## Summary
In library and favorites view, non-ascii names are all categorized under '#'.
Jellyfin server provides a transliterate field `SortName` that could further categorize non-ascii names under a-z.

Jellyfin-web has additional requests for `NameLessThan=A` or `NameStartsWith=` that filters on server side and also queries `SortName`.
https://github.com/jellyfin/jellyfin/blob/aa3fc60b2e72eb677336d4387d1f3e4a31c934f6/Jellyfin.Server.Implementations/Item/BaseItemRepository.QueryBuilding.cs#L193-L214
https://github.com/jellyfin/jellyfin-web/blob/fb7577e8e8660bc56a1ecbb07c3079098d6f8408/src/utils/items.ts#L115-L123

## Related Issues
Link related issues or tickets separated by commas.

- Related to https://github.com/jellyfin/jellyfin/pull/11172

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Add SortName to requested Fields so it is available from the API.
- Use SortName instead of Name when determining the start letter.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a library containing a media that starts with non-latin characters.
2. Click '#' and the corresponding SortName first character to confirm the media is categorized correctly.
3. Open favorites tab and repeat above.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
