### PR TITLE
feat: Remember sort order

### DIFF
--- a/packages/app/src/views/Favorites/Favorites.js
+++ b/packages/app/src/views/Favorites/Favorites.js
@@ -51,7 +51,7 @@ const unifiedMode = settings.unifiedLibraryMode && hasMultipleServers;
 const [allItems, setAllItems] = useState([]);
 const [isLoading, setIsLoading] = useState(true);
 const [totalCount, setTotalCount] = useState(0);
-const [sortKey, setSortKey] = useState('SortName');
+const [sortKey, setSortKey] = useStorage('favorites_sortKey', 'SortName');
 const [typeFilterKey, setTypeFilterKey] = useState('all');
 const [startLetter, setStartLetter] = useState(null);
 const [showSortPanel, setShowSortPanel] = useState(false);
@@ -266,7 +266,7 @@ setSortKey(key);
 setShowSortPanel(false);
 setTimeout(() => Spotlight.focus('favorites-grid'), 100);
 }
-}, []);
+}, [setSortKey]);
 
 const handleTypeFilterSelect = useCallback((ev) => {
 const key = ev.currentTarget?.dataset?.filterKey;

--- a/packages/app/src/views/Genres/Genres.js
+++ b/packages/app/src/views/Genres/Genres.js
@@ -37,7 +37,7 @@ const {settings} = useSettings();
 const unifiedMode = settings.unifiedLibraryMode && hasMultipleServers;
 const [genres, setGenres] = useState([]);
 const [isLoading, setIsLoading] = useState(true);
-const [sortOrder, setSortOrder] = useState('name-asc');
+const [sortOrder, setSortOrder] = useStorage('genres_sortOrder', 'name-asc');
 const [selectedLibrary, setSelectedLibrary] = useState(null);
 const [libraries, setLibraries] = useState([]);
 const [showSortPanel, setShowSortPanel] = useState(false);
@@ -310,7 +310,7 @@ setSortOrder(key);
 setShowSortPanel(false);
 setTimeout(() => Spotlight.focus('genres-grid'), 100);
 }
-}, []);
+}, [setSortOrder]);
 
 const handleLibrarySelect = useCallback((ev) => {
 const libIndex = ev.currentTarget?.dataset?.libIndex;

--- a/packages/app/src/views/Library/Library.js
+++ b/packages/app/src/views/Library/Library.js
@@ -90,7 +90,6 @@ const isSquareDefault = isMusicLibrary || isPlaylistLibrary;
 const [allItems, setAllItems] = useState([]);
 const [isLoading, setIsLoading] = useState(true);
 const [totalCount, setTotalCount] = useState(0);
-const [sortKey, setSortKey] = useState('SortName');
 const [favoritesOnly, setFavoritesOnly] = useState(false);
 const [watchedOnly, setWatchedOnly] = useState(false);
 const [musicContentType, setMusicContentType] = useState('albums');
@@ -107,6 +106,7 @@ const [imageSize, setImageSize] = useStorage(`library_imageSize_${libraryId}`, '
 const [imageType, setImageType] = useStorage(`library_imageType_${libraryId}`, isSquareDefault ? 'square' : 'poster');
 const [gridDirection, setGridDirection] = useStorage(`library_gridDirection_${libraryId}`, 'vertical');
 const [folderView, setFolderView] = useStorage(`library_folderView_${libraryId}`, 'off');
+const [sortKey, setSortKey] = useStorage(`library_sortKey_${libraryId}`, 'SortName');
 const isMixedContentLibrary = library != null && (!library.CollectionType || library.CollectionType.toLowerCase() === 'folders');
 const folderViewMode = settings.folderViewMode || 'local';
 const isFolderView =
@@ -460,7 +460,6 @@ const handleMusicViewJump = useCallback((e) => {
 	if (!viewId) return;
 	setMusicGridView(viewId);
 	setMusicContentType(viewId);
-	setSortKey('SortName');
 	setAllItems([]);
 	apiFetchIndexRef.current = 0;
 	initialFocusDoneRef.current = false;
@@ -598,7 +597,7 @@ setSortKey(key);
 setShowSortPanel(false);
 setTimeout(() => Spotlight.focus('library-grid'), 100);
 }
-}, []);
+}, [setSortKey]);
 
 const handleToggleFavorites = useCallback(() => {
 setFavoritesOnly(prev => !prev);


### PR DESCRIPTION
# Pull Request

## Summary
Save sort order in favorites, genres, and library view for persistence across sessions.
Remove hardcoded sort order in music library view.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Move `sortKey`/`sortOrder` from `useState` to `useStorage`
- Remove `setSortKey('SortName')` in `handleMusicViewJump`

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open favorites view and change the sort order to a non default value.
2. Open any item and go back, or go back to home and re-enter favorites view.
3. Confirm that the previous selected sort order still applies.
4. Repeat above steps for genre view, different libraries view including music libraries.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
