### PR TITLE
feat: Retrieve embedded fonts URL for ASS rendering

### DIFF
--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -651,7 +651,7 @@ export const getAssFontsUrl = (subtitleStream) => {
 	const apiKey = serverCredentials?.accessToken || jellyfinApi.getApiKey();
 	const embeddedFonts = (mediaSource?.MediaAttachments || [])
 		.filter((attachment) => supportedAssFontMimeTypes.includes(attachment.MimeType))
-		.map((attachment) => attachment.DeliveryUrl ? `${serverUrl}${attachment.DeliveryUrl}` : '')
+		.map((attachment) => attachment.DeliveryUrl ? `${serverUrl}${attachment.DeliveryUrl}?api_key=${apiKey}` : '')
 		.filter(Boolean);
 
 	return embeddedFonts;

--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -634,6 +634,29 @@ export const getAssSubtitleUrl = (subtitleStream) => {
 	return `${serverUrl}/Videos/${itemId}/${mediaSourceId}/Subtitles/${subtitleStream.index}/Stream.ass?api_key=${apiKey}`;
 };
 
+const supportedAssFontMimeTypes = [
+	'application/vnd.ms-opentype',
+	'application/x-truetype-font',
+	'font/otf',
+	'font/ttf',
+	'font/woff',
+	'font/woff2'
+];
+
+export const getAssFontsUrl = (subtitleStream) => {
+	if (!subtitleStream?.isAss || !currentSession) return [];
+
+	const {mediaSource, serverCredentials} = currentSession;
+	const serverUrl = serverCredentials?.serverUrl || jellyfinApi.getServerUrl();
+	const apiKey = serverCredentials?.accessToken || jellyfinApi.getApiKey();
+	const embeddedFonts = (mediaSource?.MediaAttachments || [])
+		.filter((attachment) => supportedAssFontMimeTypes.includes(attachment.MimeType))
+		.map((attachment) => attachment.DeliveryUrl ? `${serverUrl}${attachment.DeliveryUrl}` : '')
+		.filter(Boolean);
+
+	return embeddedFonts;
+};
+
 /**
  * Fetch subtitle track events as JSON data for custom rendering
  * This is required on webOS because native <track> elements don't work reliably

--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -636,7 +636,11 @@ export const getAssSubtitleUrl = (subtitleStream) => {
 
 const supportedAssFontMimeTypes = [
 	'application/vnd.ms-opentype',
+	'application/font-sfnt',
+	'application/x-font-ttf',
 	'application/x-truetype-font',
+	'font/collection',
+	'font/sfnt',
 	'font/otf',
 	'font/ttf',
 	'font/woff',

--- a/packages/app/src/utils/assRenderer.js
+++ b/packages/app/src/utils/assRenderer.js
@@ -25,8 +25,8 @@ export const supportsAssRenderer = () => {
 
 const supportsWasmBlend = () => {
 	const chromiumMajor = getChromiumMajorVersion();
-	if (chromiumMajor && chromiumMajor < 57) return false;
-	return true;
+	if (chromiumMajor && chromiumMajor >= 57) return true;
+	return false;
 };
 
 const createRenderer = async (options, onError) => {

--- a/packages/app/src/utils/assRenderer.js
+++ b/packages/app/src/utils/assRenderer.js
@@ -47,16 +47,16 @@ const createRenderer = async (options, onError) => {
 	}
 };
 
-export const initAssRenderer = async (videoElement, subtitleUrl, onError) => {
+export const initAssRenderer = async (videoElement, subtitleUrl, fontsUrl, onError) => {
 	if (!videoElement || !subtitleUrl) return null;
-	return createRenderer({video: videoElement, subUrl: subtitleUrl}, onError);
+	return createRenderer({video: videoElement, subUrl: subtitleUrl, fonts: fontsUrl}, onError);
 };
 
-export const initAssCanvasRenderer = async (canvasElement, subtitleUrl, onError) => {
+export const initAssCanvasRenderer = async (canvasElement, subtitleUrl, fontsUrl, onError) => {
 	if (!canvasElement || !subtitleUrl) return null;
 	canvasElement.width = window.innerWidth || canvasElement.clientWidth || 1920;
 	canvasElement.height = window.innerHeight || canvasElement.clientHeight || 1080;
-	return createRenderer({canvas: canvasElement, subUrl: subtitleUrl}, onError);
+	return createRenderer({canvas: canvasElement, subUrl: subtitleUrl, fonts: fontsUrl}, onError);
 };
 
 export const disposeAssRenderer = (renderer) => {

--- a/packages/app/src/utils/assRenderer.js
+++ b/packages/app/src/utils/assRenderer.js
@@ -23,11 +23,20 @@ export const supportsAssRenderer = () => {
 	return true;
 };
 
+const supportsWasmBlend = () => {
+	const chromiumMajor = getChromiumMajorVersion();
+	if (chromiumMajor && chromiumMajor < 57) return false;
+	return true;
+};
+
 const createRenderer = async (options, onError) => {
 	try {
 		const mod = await import('libass-wasm');
 		const SubtitlesOctopus = mod.default || mod;
 		const workerUrl = 'subtitles-octopus-worker.js';
+		const qualityOptions = supportsWasmBlend()
+			? { targetFps: 24, renderMode: 'wasm-blend', prescaleFactor: 0.8, maxRenderHeight: 2160}
+			: { targetFps: 10, renderMode: 'js-blend', prescaleFactor: 0.5, maxRenderHeight: 540};
 
 		return new SubtitlesOctopus({
 			...options,
@@ -35,10 +44,7 @@ const createRenderer = async (options, onError) => {
 			legacyWorkerUrl: workerUrl.replace('worker.js', 'worker-legacy.js'),
 			fallbackFont: 'ass-fallback-font.ttf',
 			onError: onError || null,
-			targetFps: 10,
-			renderMode: 'js-blend',
-			prescaleFactor: 0.5,
-			maxRenderHeight: 540,
+			...qualityOptions,
 			debug: false
 		});
 	} catch (err) {

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -1454,7 +1454,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				try {
 					const assUrl = playback.getAssSubtitleUrl(stream);
 					if (assUrl && pgsCanvasRef.current) {
-						const assFontsUrl = playback.getAssFontsUrl(sub);
+						const assFontsUrl = playback.getAssFontsUrl(stream);
 						const assErrorHandler = (err) => {
 							console.error('[Player] ASS renderer error, falling back to text', err);
 							disposeAssRenderer(assRendererRef.current);

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -598,6 +598,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 						try {
 							const assUrl = playback.getAssSubtitleUrl(sub);
 							if (assUrl && pgsCanvasRef.current) {
+								const assFontsUrl = playback.getAssFontsUrl(sub);
 								const assErrorHandler = (err) => {
 									console.error('[Player] ASS renderer error, falling back to text', err);
 									disposeAssRenderer(assRendererRef.current);
@@ -606,7 +607,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 										setSubtitleTrackEvents(data?.TrackEvents || null);
 									}).catch(() => setSubtitleTrackEvents(null));
 								};
-								const renderer = await initAssCanvasRenderer(pgsCanvasRef.current, assUrl, assErrorHandler);
+								const renderer = await initAssCanvasRenderer(pgsCanvasRef.current, assUrl, assFontsUrl, assErrorHandler);
 								if (renderer) {
 									assRendererRef.current = renderer;
 									setSubtitleTrackEvents(null);
@@ -1453,6 +1454,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				try {
 					const assUrl = playback.getAssSubtitleUrl(stream);
 					if (assUrl && pgsCanvasRef.current) {
+						const assFontsUrl = playback.getAssFontsUrl(sub);
 						const assErrorHandler = (err) => {
 							console.error('[Player] ASS renderer error, falling back to text', err);
 							disposeAssRenderer(assRendererRef.current);
@@ -1461,7 +1463,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 								setSubtitleTrackEvents(data?.TrackEvents || null);
 							}).catch(() => setSubtitleTrackEvents(null));
 						};
-						const renderer = await initAssCanvasRenderer(pgsCanvasRef.current, assUrl, assErrorHandler);
+						const renderer = await initAssCanvasRenderer(pgsCanvasRef.current, assUrl, assFontsUrl, assErrorHandler);
 						if (renderer) {
 							assRendererRef.current = renderer;
 							setSubtitleTrackEvents(null);

--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -351,8 +351,9 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			if (!assUrl) {
 				return false;
 			}
+			const assFontsUrl = playback.getAssFontsUrl(stream);
 
-			const renderer = await initAssRenderer(videoRef.current, assUrl, (err) => {
+			const renderer = await initAssRenderer(videoRef.current, assUrl, assFontsUrl, (err) => {
 				console.error('[Player] ASS renderer error, falling back to text', err);
 				disposeAssRenderer(assRendererRef.current);
 				assRendererRef.current = null;


### PR DESCRIPTION
# Pull Request

## Summary
For media with embedded fonts, pass URL to SubtitlesOctopus.
Use `wasm-blend` and higher quality options for supported browser.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Add `getAssFontsUrl` to extract links for valid fonts from attachments
- Retrieve and pass `assFontsUrl` to assRender for both Tizen and WebOS player
- Enable wasm support and higher quality options on Chromium 57+

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a media with ASS subtitles and embedded fonts

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
