### PR TITLE
fix missing lastplayed for nextup items in merge cwnu

### DIFF
--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -1313,6 +1313,7 @@ const Browse = ({
 		settings.genresRowItemFilter,
 		settings.uiLanguage,
 		settings.pluginSections,
+		settings.mergeContinueWatchingNextUp,
 		isCacheValid,
 		loadBrowseCache,
 		saveBrowseCache,

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -452,15 +452,28 @@ const Browse = ({
 		if (settings.mergeContinueWatchingNextUp) {
 			const mergeResumeRow = allRowData.find(r => r.id === 'resume');
 			const nextUpRow = allRowData.find(r => r.id === 'nextup');
+			const recentlyPlayed = allRowData.find(r => r.id === 'recentlyplayed');
 
 			result = allRowData.filter(r => r.id !== 'resume' && r.id !== 'nextup');
 
 			if (mergeResumeRow || nextUpRow) {
 				const resumeItems = mergeResumeRow?.items || [];
 				const nextUpItems = nextUpRow?.items || [];
+				const recentlyPlayedItems = recentlyPlayed?.items || [];
 
 				const seriesLastPlayedMap = new Map();
 				resumeItems.forEach(item => {
+					const seriesId = item.SeriesId;
+					const lastPlayed = item.UserData?.LastPlayedDate;
+					if (seriesId && lastPlayed) {
+						const existing = seriesLastPlayedMap.get(seriesId);
+						if (!existing || lastPlayed > existing) {
+							seriesLastPlayedMap.set(seriesId, lastPlayed);
+						}
+					}
+				});
+
+				recentlyPlayedItems.forEach(item => {
 					const seriesId = item.SeriesId;
 					const lastPlayed = item.UserData?.LastPlayedDate;
 					if (seriesId && lastPlayed) {
@@ -832,7 +845,7 @@ const Browse = ({
 
 		const fetchAllData = async () => {
 			try {
-				let libs, resumeItems, nextUp, userConfig, randomItems;
+				let libs, resumeItems, nextUp, userConfig, randomItems, recentlyPlayed;
 
 				if (unifiedMode) {
 					const [libsArray, resumeArray, nextUpArray, randomArray] = await Promise.all([
@@ -846,19 +859,30 @@ const Browse = ({
 					nextUp = {Items: nextUpArray};
 					userConfig = null; // Not supported in unified mode
 					randomItems = {Items: randomArray};
+					recentlyPlayed = null;
 				} else {
 					const results = await Promise.all([
 						api.getLibraries(),
 						api.getResumeItems(),
 						api.getNextUp(),
 						api.getUserConfiguration().catch(() => null),
-						api.getRandomItems(settings.featuredContentType, settings.featuredItemCount)
+						api.getRandomItems(settings.featuredContentType, settings.featuredItemCount),
+						api.getItems({
+							IncludeItemTypes: 'Episode',
+							Filters: 'IsPlayed',
+							Recursive: true,
+							SortBy: 'DatePlayed',
+							SortOrder: 'Descending',
+							Limit: 100,
+							Fields: 'UserData,SeriesId'
+						})
 					]);
 					libs = results[0].Items || [];
 					resumeItems = results[1];
 					nextUp = results[2];
 					userConfig = results[3];
 					randomItems = results[4];
+					recentlyPlayed = results[5];
 				}
 
 				cachedLibraries = libs;
@@ -910,6 +934,13 @@ const Browse = ({
 						LogoUrl: getLogoUrl(getItemServerUrl(item), item, {maxWidth: 800, quality: 90})
 					}));
 					cachedFeaturedItems = featuredWithLogos;
+				}
+
+				if (recentlyPlayed.Items?.length > 0) {
+					rowData.push({
+						id: 'recentlyplayed',
+						items: recentlyPlayed.Items
+					});
 				}
 
 				dispatch({type: 'SET_INITIAL_DATA', rowData, featuredItems: cachedFeaturedItems});

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -867,7 +867,7 @@ const Browse = ({
 						api.getNextUp(),
 						api.getUserConfiguration().catch(() => null),
 						api.getRandomItems(settings.featuredContentType, settings.featuredItemCount),
-						api.getItems({
+						settings.mergeContinueWatchingNextUp ? api.getItems({
 							IncludeItemTypes: 'Episode',
 							Filters: 'IsPlayed',
 							Recursive: true,

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -875,7 +875,7 @@ const Browse = ({
 							SortOrder: 'Descending',
 							Limit: 100,
 							Fields: 'UserData,SeriesId'
-						})
+						}) : Promise.resolve(null)
 					]);
 					libs = results[0].Items || [];
 					resumeItems = results[1];

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -936,7 +936,7 @@ const Browse = ({
 					cachedFeaturedItems = featuredWithLogos;
 				}
 
-				if (recentlyPlayed.Items?.length > 0) {
+				if (recentlyPlayed?.Items?.length > 0) {
 					rowData.push({
 						id: 'recentlyplayed',
 						items: recentlyPlayed.Items


### PR DESCRIPTION
# Pull Request

## Summary
Currently lastPlayedMap only contains data from the resume items. So any nextup items that don't have a cw item from the same series would be missing lastPlayedDate and not get sorted properly when merging cw/nu. 

I added recentlyPlayed similar to moonfin-core and use that to populate remaining series lastPlayedDate. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add recentlyPlayed to fetchAllData.rowData
- populate lastPlayedMap with recentlyPlayed data
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Turn on "merge cwnu"
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="3581" height="859" alt="image" src="https://github.com/user-attachments/assets/b23a451b-3e09-4a0f-9fbf-3d7ec7055e46" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
