### PR TITLE
add recently released rows

### DIFF
--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -187,6 +187,7 @@ const LOCAL_TO_SERVER = Object.fromEntries(
 
 const TV_TO_SERVER_ROW = {
 	'latest-media': 'latestmedia',
+	'recently-released': 'recentlyreleased',
 	'library-tiles': 'smalllibrarytiles',
 	'favoriteMovies': 'favoritemovies',
 	'favoriteSeries': 'favoriteseries',
@@ -200,6 +201,7 @@ const TV_TO_SERVER_ROW = {
 };
 const SERVER_TO_TV_ROW = {
 	'latestmedia': 'latest-media',
+	'recentlyreleased': 'recently-released',
 	'smalllibrarytiles': 'library-tiles',
 	'favoritemovies': 'favoriteMovies',
 	'favoriteseries': 'favoriteSeries',

--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -7,7 +7,7 @@ import {getAvailableThemeList, getAvailableThemes, isBuiltInThemeId, registerSto
 const DEFAULT_HOME_ROWS = [
 	{id: 'resume', name: 'Continue Watching', enabled: true, order: 0},
 	{id: 'nextup', name: 'Next Up', enabled: true, order: 1},
-	{id: 'latest-media', name: 'Latest Media', enabled: true, order: 2},
+	{id: 'latest-media', name: 'Recently Added Media', enabled: true, order: 2},
 	{id: 'collections', name: 'Collections', enabled: false, order: 3},
 	{id: 'library-tiles', name: 'My Media', enabled: false, order: 4},
 	{id: 'favoriteMovies', name: 'Favorite Movies', enabled: false, order: 5},
@@ -18,7 +18,8 @@ const DEFAULT_HOME_ROWS = [
 	{id: 'favoriteMusicVideos', name: 'Favorite Music Videos', enabled: false, order: 10},
 	{id: 'favoriteAlbums', name: 'Favorite Albums', enabled: false, order: 11},
 	{id: 'favoriteSongs', name: 'Favorite Songs', enabled: false, order: 12},
-	{id: 'genres', name: 'Genres', enabled: false, order: 13}
+	{id: 'genres', name: 'Genres', enabled: false, order: 13},
+	{id: 'recently-released', name: 'Recently Released', enabled: false, order: 14}
 ];
 
 const DEFAULT_SEERR_HOME_ROWS = [

--- a/packages/app/src/services/jellyfinApi.js
+++ b/packages/app/src/services/jellyfinApi.js
@@ -197,6 +197,9 @@ export const api = {
 	getLatest: (libraryId, limit = 20) =>
 		request(`/Users/${currentUser}/Items/Latest?ParentId=${libraryId}&Limit=${limit}&Fields=${encodeURIComponent(HOME_ROW_ITEM_FIELDS)}&ImageTypeLimit=1&GroupItems=true`),
 
+	getRecentlyReleased: (libraryId, limit = 20) =>
+		request(`/Users/${currentUser}/Items?ParentId=${libraryId}&Limit=${limit}&Fields=${encodeURIComponent(HOME_ROW_ITEM_FIELDS)}&ImageTypeLimit=1&GroupItems=true&sortBy=PremiereDate&SortOrder=Descending`),
+
 	getCollections: (limit = 50, sortBy = 'SortName', sortOrder = 'Ascending') =>
 		request(`/Users/${currentUser}/Items?IncludeItemTypes=BoxSet&Recursive=true&SortBy=${encodeURIComponent(sortBy)}&SortOrder=${encodeURIComponent(sortOrder)}&Limit=${limit}&Fields=PrimaryImageAspectRatio,ProductionYear`),
 

--- a/packages/app/src/services/jellyfinApi.js
+++ b/packages/app/src/services/jellyfinApi.js
@@ -198,7 +198,7 @@ export const api = {
 		request(`/Users/${currentUser}/Items/Latest?ParentId=${libraryId}&Limit=${limit}&Fields=${encodeURIComponent(HOME_ROW_ITEM_FIELDS)}&ImageTypeLimit=1&GroupItems=true`),
 
 	getRecentlyReleased: (libraryId, limit = 20) =>
-		request(`/Users/${currentUser}/Items?IncludeItemTypes=Movie,Series&Recursive=true&ParentId=${libraryId}&Limit=${limit}&Fields=ImageTags,ParentThumbItemId,ParentBackdropItemId&ImageTypeLimit=1&SortBy=PremiereDate&SortOrder=Descending`),
+		request(`/Users/${currentUser}/Items?IncludeItemTypes=Movie,Series&Recursive=true&ParentId=${libraryId}&Limit=${limit}&Fields=${encodeURIComponent(HOME_ROW_ITEM_FIELDS)}&ImageTypeLimit=1&SortBy=PremiereDate&SortOrder=Descending&MaxPremiereDate=${encodeURIComponent(new Date().toISOString())}`),
 
 	getCollections: (limit = 50, sortBy = 'SortName', sortOrder = 'Ascending') =>
 		request(`/Users/${currentUser}/Items?IncludeItemTypes=BoxSet&Recursive=true&SortBy=${encodeURIComponent(sortBy)}&SortOrder=${encodeURIComponent(sortOrder)}&Limit=${limit}&Fields=PrimaryImageAspectRatio,ProductionYear`),

--- a/packages/app/src/services/jellyfinApi.js
+++ b/packages/app/src/services/jellyfinApi.js
@@ -198,7 +198,7 @@ export const api = {
 		request(`/Users/${currentUser}/Items/Latest?ParentId=${libraryId}&Limit=${limit}&Fields=${encodeURIComponent(HOME_ROW_ITEM_FIELDS)}&ImageTypeLimit=1&GroupItems=true`),
 
 	getRecentlyReleased: (libraryId, limit = 20) =>
-		request(`/Users/${currentUser}/Items?ParentId=${libraryId}&Limit=${limit}&Fields=${encodeURIComponent(HOME_ROW_ITEM_FIELDS)}&ImageTypeLimit=1&GroupItems=true&sortBy=PremiereDate&SortOrder=Descending`),
+		request(`/Users/${currentUser}/Items?IncludeItemTypes=Movie,Series&Recursive=true&ParentId=${libraryId}&Limit=${limit}&Fields=ImageTags,ParentThumbItemId,ParentBackdropItemId&ImageTypeLimit=1&SortBy=PremiereDate&SortOrder=Descending`),
 
 	getCollections: (limit = 50, sortBy = 'SortName', sortOrder = 'Ascending') =>
 		request(`/Users/${currentUser}/Items?IncludeItemTypes=BoxSet&Recursive=true&SortBy=${encodeURIComponent(sortBy)}&SortOrder=${encodeURIComponent(sortOrder)}&Limit=${limit}&Fields=PrimaryImageAspectRatio,ProductionYear`),

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -1264,8 +1264,8 @@ const Browse = ({
 						),
 						Promise.all(
 							eligibleLibraries.map(lib =>
-								api.getLatest(lib.Id, 16)
-									.then(latest => ({lib, latest}))
+								api.getRecentlyReleased(lib.Id, 16)
+									.then(result => ({lib, result}))
 									.catch(() => null)
 							)
 						),
@@ -1317,7 +1317,7 @@ const Browse = ({
 				}
 
 				for (const result of recentlyReleasedResults) {
-					if (result && result.latest?.length > 0) {
+					if (result && result.result?.length > 0) {
 						const libraryTitle = unifiedMode && result.lib._serverName
 							? `${result.lib.Name} (${result.lib._serverName})`
 							: result.lib.Name;
@@ -1326,7 +1326,7 @@ const Browse = ({
 						newRows.push({
 							id: rowId,
 							title: $L('Recently Released in {libraryTitle}').replace('{libraryTitle}', libraryTitle),
-							items: result.latest,
+							items: result.result,
 							library: result.lib,
 							type: result.lib.CollectionType?.toLowerCase() === 'music' ? 'square' : 'portrait',
 							isRecentlyReleasedRow: true

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -611,8 +611,8 @@ const Browse = ({
 				title = $L('Recently Added in {libraryTitle}').replace('{libraryTitle}', libName);
 			} else if (row.isRecentlyReleasedRow && row.library) {
 				const libName = row.library._serverName
-				? `${row.library.Name} (${row.library._serverName})`
-				: row.library.Name;
+					? `${row.library.Name} (${row.library._serverName})`
+					: row.library.Name;
 				title = $L('Recently Released in {libraryTitle}').replace('{libraryTitle}', libName);
 			}
 			return title && title !== row.title ? {...row, title} : row;

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -1265,7 +1265,7 @@ const Browse = ({
 						Promise.all(
 							eligibleLibraries.map(lib =>
 								api.getRecentlyReleased(lib.Id, 16)
-									.then(result => ({lib, result}))
+									.then(latest => ({lib, latest}))
 									.catch(() => null)
 							)
 						),
@@ -1317,7 +1317,7 @@ const Browse = ({
 				}
 
 				for (const result of recentlyReleasedResults) {
-					if (result && result.result?.length > 0) {
+					if (result && result.latest.Items?.length > 0) {
 						const libraryTitle = unifiedMode && result.lib._serverName
 							? `${result.lib.Name} (${result.lib._serverName})`
 							: result.lib.Name;
@@ -1326,7 +1326,7 @@ const Browse = ({
 						newRows.push({
 							id: rowId,
 							title: $L('Recently Released in {libraryTitle}').replace('{libraryTitle}', libraryTitle),
-							items: result.result,
+							items: result.latest.Items,
 							library: result.lib,
 							type: result.lib.CollectionType?.toLowerCase() === 'music' ? 'square' : 'portrait',
 							isRecentlyReleasedRow: true

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -558,6 +558,7 @@ const Browse = ({
 				if (row.isPluginRow) return enabledPluginIds.includes(row.id);
 				if (!isRowVisibleByGates(row.id)) return false;
 				if (row.isLatestRow) return enabledRowIds.includes('latest-media');
+				if (row.isRecentlyReleasedRow) return enabledRowIds.includes('recently-released');
 				return enabledRowIds.includes(row.id);
 			});
 		} else {
@@ -583,6 +584,9 @@ const Browse = ({
 					if (row.isLatestRow) {
 						return enabledRowIds.includes('latest-media');
 					}
+					if (row.isRecentlyReleasedRow) {
+						return enabledRowIds.includes('recently-released');
+					}
 					if (!isRowVisibleByGates(row.id)) {
 						return false;
 					}
@@ -604,7 +608,12 @@ const Browse = ({
 				const libName = row.library._serverName
 					? `${row.library.Name} (${row.library._serverName})`
 					: row.library.Name;
-				title = $L('Latest in {libraryTitle}').replace('{libraryTitle}', libName);
+				title = $L('Recently Added in {libraryTitle}').replace('{libraryTitle}', libName);
+			} else if (row.isRecentlyReleasedRow && row.library) {
+				const libName = row.library._serverName
+				? `${row.library.Name} (${row.library._serverName})`
+				: row.library.Name;
+				title = $L('Recently Released in {libraryTitle}').replace('{libraryTitle}', libName);
 			}
 			return title && title !== row.title ? {...row, title} : row;
 		});
@@ -625,6 +634,8 @@ const Browse = ({
 					order = Number.isFinite(continueOrder) ? continueOrder : 0;
 				} else if (row.isLatestRow) {
 					order = rowOrderMap.get('latest-media');
+				} else if (row.isRecentlyReleasedRow) {
+					order = rowOrderMap.get('recently-released');
 				} else if (row.isSeerrRow) {
 					order = 3000 + index;
 				}
@@ -1005,6 +1016,7 @@ const Browse = ({
 				});
 
 				let latestResults;
+				let recentlyReleasedResults;
 				let collectionsResult = null;
 				let favoriteResults = [];
 				let genresResult = null;
@@ -1242,7 +1254,14 @@ const Browse = ({
 					const genresIncludeTypes = getGenresIncludeTypes(settings.genresRowItemFilter);
 					const enabledPluginSections = (settings.pluginSections || []).filter((section) => section.enabled);
 
-					[latestResults, collectionsResult, favoriteResults, genresResult, pluginRows] = await Promise.all([
+					[latestResults, recentlyReleasedResults, collectionsResult, favoriteResults, genresResult, pluginRows] = await Promise.all([
+						Promise.all(
+							eligibleLibraries.map(lib =>
+								api.getLatest(lib.Id, 16)
+									.then(latest => ({lib, latest}))
+									.catch(() => null)
+							)
+						),
 						Promise.all(
 							eligibleLibraries.map(lib =>
 								api.getLatest(lib.Id, 16)
@@ -1288,11 +1307,29 @@ const Browse = ({
 
 						newRows.push({
 							id: rowId,
-							title: $L('Latest in {libraryTitle}').replace('{libraryTitle}', libraryTitle),
+							title: $L('Recently Added in {libraryTitle}').replace('{libraryTitle}', libraryTitle),
 							items: result.latest,
 							library: result.lib,
 							type: result.lib.CollectionType?.toLowerCase() === 'music' ? 'square' : 'portrait',
 							isLatestRow: true
+						});
+					}
+				}
+
+				for (const result of recentlyReleasedResults) {
+					if (result && result.latest?.length > 0) {
+						const libraryTitle = unifiedMode && result.lib._serverName
+							? `${result.lib.Name} (${result.lib._serverName})`
+							: result.lib.Name;
+						const rowId = `recently-released-${result.lib.Id}${result.lib._serverName ? '-' + result.lib._serverName : ''}`;
+
+						newRows.push({
+							id: rowId,
+							title: $L('Recently Released in {libraryTitle}').replace('{libraryTitle}', libraryTitle),
+							items: result.latest,
+							library: result.lib,
+							type: result.lib.CollectionType?.toLowerCase() === 'music' ? 'square' : 'portrait',
+							isRecentlyReleasedRow: true
 						});
 					}
 				}


### PR DESCRIPTION
# Pull Request

## Summary
Add rows for "recently released" for each library. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add recentlyreleased home row to settings_context
- add getRecentlyReleased to jellyfin_api
- add recentlyReleased to browse.js matching latest_media but with new api request instead 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="3690" height="1512" alt="image" src="https://github.com/user-attachments/assets/b5c4563f-d887-4911-8361-de0a725efc73" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
