### PR TITLE
remove incorrect weblate link haha

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,7 @@ Moonfin is the first smart TV client with native Jellyseerr support.
 ### Performance
 - **Automatic Performance Tuning**: Detects how capable your TV is and dials the heaviest visual effects up or down to match, so older sets stay responsive while newer ones keep the full look
 - **Performance Mode**: Choose between Auto, High Quality, Balanced, and Performance to control the tradeoff yourself
-- **Lighter visuals on weaker hardware**: Background blur is reduced or disabled where it would otherwise slow things down
-
-### Localization
-Moonfin speaks your language. Switch the app language right from Settings, with English, German, Spanish, French, Hungarian, Polish, Portuguese (Brazil), and Russian available.
-
-Translations are managed on [Weblate](https://hosted.weblate.org/projects/moonfin/smart-tv/), so anyone can help translate Moonfin into their language and new strings are picked up automatically. Want to see your language here? [Jump in and start translating.](https://hosted.weblate.org/engage/moonfin/)
-
-<a href="https://hosted.weblate.org/engage/moonfin/">
-  <img src="https://hosted.weblate.org/widgets/moonfin/-/smart-tv/multi-auto.svg" alt="Translation status" />
-</a>
+- **Lighter visuals on weaker hardware**: Background blur is reduced or disabled where it would otherwise slow things dow
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ We welcome contributions to Moonfin!
 4. Test on Samsung and/or LG TV hardware
 5. Submit a pull request with a detailed description
 
+### Translations
+If you notice issues with translations in your language, you can contribute fixed tranlations on [weblate](https://translate.moonfin.io/). 
+
 ---
 
 ## Support & Community

--- a/README.md
+++ b/README.md
@@ -294,8 +294,14 @@ We welcome contributions to Moonfin!
 4. Test on Samsung and/or LG TV hardware
 5. Submit a pull request with a detailed description
 
-### Translations
-If you notice issues with translations in your language, you can contribute fixed tranlations on [weblate](https://translate.moonfin.io/). 
+## Help translate Moonfin [here](https://translate.moonfin.io/engage/smart-tv/)
+
+<a href="https://translate.moonfin.io/engage/smart-tv/">
+  <img
+    src="https://translate.moonfin.io/widgets/smart-tv/-/multi-auto.svg"
+    alt="Moonfin SmartTV translation status by language"
+  />
+</a>
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Summary
I did not notice (or it happened after I submitted the pr? idk) but you already put the weblate link/chart in the readme for smarttv. This pr removes the one that is the old hosted link and keeps the new correct link. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [X] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- 
- 
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [ ] Code builds successfully
- [ ] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
