### PR TITLE
feat: implement synced hide filters for Continue Watching and Next Up

### DIFF
--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -75,6 +75,8 @@ const defaultSettings = {
 	showFavoritesButton: true,
 	showLibrariesInToolbar: true,
 	mergeContinueWatchingNextUp: false,
+	hiddenContinueWatchingItems: null,
+	hiddenNextUpSeries: null,
 	showHomeBackdrop: true,
 	backdropBlurHome: 20,
 	backdropBlurDetail: 20,
@@ -284,6 +286,7 @@ const VALUE_CONVERSIONS = {
 const SYNCABLE_KEYS = [
 	'showShuffleButton', 'shuffleContentType', 'showGenresButton',
 	'showFavoritesButton', 'showLibrariesInToolbar', 'mergeContinueWatchingNextUp',
+	'hiddenContinueWatchingItems', 'hiddenNextUpSeries',
 	'mdblistEnabled', 'mdblistRatingSources', 'tmdbEpisodeRatingsEnabled',
 	'navbarPosition', 'featuredBarStyle', 'featuredContentType', 'featuredItemCount',
 	'featuredTrailerPreview', 'featuredTrailerMuted', 'unifiedLibraryMode', 'seasonalTheme',

--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -335,7 +335,7 @@ const localToProfile = (localSettings) => {
 	const profile = {};
 	for (const key of SYNCABLE_KEYS) {
 		const value = localSettings[key];
-		if (value === undefined) continue;
+		if (value === undefined || value === null) continue;
 		const serverKey = LOCAL_TO_SERVER[key] || key;
 		const conv = VALUE_CONVERSIONS[key];
 		profile[serverKey] = conv?.toServer ? conv.toServer(value) : value;

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -38,6 +38,39 @@ const STORAGE_KEY_BROWSE = 'browse_cache_v2';
 let cachedRowData = null;
 let cachedLibraries = null;
 let cachedFeaturedItems = null;
+
+const parseHiddenMap = (val) => {
+	if (!val) return {};
+	try {
+		return typeof val === 'string' ? JSON.parse(val) : val;
+	} catch (e) {
+		return {};
+	}
+};
+
+const isItemHiddenFromCW = (item, hiddenCWMap) => {
+	const id = item.SeriesId || item.Id;
+	if (!id || !hiddenCWMap[id]) return false;
+	const hideTime = hiddenCWMap[id];
+	const lastPlayed = item.UserData?.LastPlayedDate;
+	if (lastPlayed) {
+		const lastPlayedMs = Date.parse(lastPlayed);
+		if (lastPlayedMs > hideTime) return false;
+	}
+	return true;
+};
+
+const isSeriesHiddenFromNextUp = (item, hiddenNUMap) => {
+	const seriesId = item.SeriesId;
+	if (!seriesId || !hiddenNUMap[seriesId]) return false;
+	const hideTime = hiddenNUMap[seriesId];
+	const lastPlayed = item.UserData?.LastPlayedDate;
+	if (lastPlayed) {
+		const lastPlayedMs = Date.parse(lastPlayed);
+		if (lastPlayedMs > hideTime) return false;
+	}
+	return true;
+};
 let cacheTimestamp = null;
 
 let lastFocusState = null;
@@ -474,6 +507,9 @@ const Browse = ({
 		homeRowsConfig.forEach((row) => rowOrderMap.set(row.id, row.order));
 		pluginSectionsConfig.forEach((section, index) => rowOrderMap.set(section.id, (section.order ?? index) + 1000));
 
+		const hiddenCWMap = parseHiddenMap(settings.hiddenContinueWatchingItems);
+		const hiddenNUMap = parseHiddenMap(settings.hiddenNextUpSeries);
+
 		let result;
 
 		if (settings.mergeContinueWatchingNextUp) {
@@ -484,8 +520,8 @@ const Browse = ({
 			result = allRowData.filter(r => r.id !== 'resume' && r.id !== 'nextup');
 
 			if (mergeResumeRow || nextUpRow) {
-				const resumeItems = mergeResumeRow?.items || [];
-				const nextUpItems = nextUpRow?.items || [];
+				const resumeItems = (mergeResumeRow?.items || []).filter(item => !isItemHiddenFromCW(item, hiddenCWMap));
+				const nextUpItems = (nextUpRow?.items || []).filter(item => !isSeriesHiddenFromNextUp(item, hiddenNUMap) && !isItemHiddenFromCW(item, hiddenCWMap));
 				const recentlyPlayedItems = recentlyPlayed?.items || [];
 
 				const seriesLastPlayedMap = new Map();
@@ -562,12 +598,16 @@ const Browse = ({
 			});
 		} else {
 			const resumeRow = allRowData.find(r => r.id === 'resume');
-			const resumeItemIds = new Set((resumeRow?.items || []).map(item => item.Id));
+			const resumeItems = (resumeRow?.items || []).filter(item => !isItemHiddenFromCW(item, hiddenCWMap));
+			const resumeItemIds = new Set(resumeItems.map(item => item.Id));
 
 			result = allRowData
 				.map(row => {
-					if (row.id === 'nextup' && resumeItemIds.size > 0) {
-						const filteredItems = row.items.filter(item => !resumeItemIds.has(item.Id));
+					if (row.id === 'resume') {
+						return {...row, items: resumeItems};
+					}
+					if (row.id === 'nextup') {
+						const filteredItems = row.items.filter(item => !resumeItemIds.has(item.Id) && !isSeriesHiddenFromNextUp(item, hiddenNUMap) && !isItemHiddenFromCW(item, hiddenCWMap));
 						return filteredItems.length > 0 ? {...row, items: filteredItems} : null;
 					}
 					return row;
@@ -656,7 +696,7 @@ const Browse = ({
 
 		prevFilteredRowsRef.current = result;
 		return result;
-	}, [allRowData, seerrRows, homeRowsConfig, pluginSectionsConfig, settings.mergeContinueWatchingNextUp, isRowVisibleByGates]);
+	}, [allRowData, seerrRows, homeRowsConfig, pluginSectionsConfig, settings.mergeContinueWatchingNextUp, settings.hiddenContinueWatchingItems, settings.hiddenNextUpSeries, isRowVisibleByGates]);
 
 	const focusRow = useCallback((rowIndex) => {
 		const row = filteredRowsRef.current[rowIndex];

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -48,26 +48,16 @@ const parseHiddenMap = (val) => {
 	}
 };
 
-const isItemHiddenFromCW = (item, hiddenCWMap) => {
-	const id = item.SeriesId || item.Id;
-	if (!id || !hiddenCWMap[id]) return false;
-	const hideTime = hiddenCWMap[id];
+// seriesOnly keys on the series id only, otherwise it falls back to the item id.
+const isHiddenByMap = (item, hiddenMap, seriesOnly) => {
+	const key = seriesOnly ? item.SeriesId : (item.SeriesId || item.Id);
+	if (!key || !hiddenMap[key]) return false;
+	// Hide timestamps are stored as ISO strings, so parse before comparing.
+	const hideTimeMs = Date.parse(hiddenMap[key]);
 	const lastPlayed = item.UserData?.LastPlayedDate;
 	if (lastPlayed) {
 		const lastPlayedMs = Date.parse(lastPlayed);
-		if (lastPlayedMs > hideTime) return false;
-	}
-	return true;
-};
-
-const isSeriesHiddenFromNextUp = (item, hiddenNUMap) => {
-	const seriesId = item.SeriesId;
-	if (!seriesId || !hiddenNUMap[seriesId]) return false;
-	const hideTime = hiddenNUMap[seriesId];
-	const lastPlayed = item.UserData?.LastPlayedDate;
-	if (lastPlayed) {
-		const lastPlayedMs = Date.parse(lastPlayed);
-		if (lastPlayedMs > hideTime) return false;
+		if (lastPlayedMs > hideTimeMs) return false;
 	}
 	return true;
 };
@@ -520,8 +510,8 @@ const Browse = ({
 			result = allRowData.filter(r => r.id !== 'resume' && r.id !== 'nextup');
 
 			if (mergeResumeRow || nextUpRow) {
-				const resumeItems = (mergeResumeRow?.items || []).filter(item => !isItemHiddenFromCW(item, hiddenCWMap));
-				const nextUpItems = (nextUpRow?.items || []).filter(item => !isSeriesHiddenFromNextUp(item, hiddenNUMap) && !isItemHiddenFromCW(item, hiddenCWMap));
+				const resumeItems = (mergeResumeRow?.items || []).filter(item => !isHiddenByMap(item, hiddenCWMap, false));
+				const nextUpItems = (nextUpRow?.items || []).filter(item => !isHiddenByMap(item, hiddenNUMap, true));
 				const recentlyPlayedItems = recentlyPlayed?.items || [];
 
 				const seriesLastPlayedMap = new Map();
@@ -598,7 +588,7 @@ const Browse = ({
 			});
 		} else {
 			const resumeRow = allRowData.find(r => r.id === 'resume');
-			const resumeItems = (resumeRow?.items || []).filter(item => !isItemHiddenFromCW(item, hiddenCWMap));
+			const resumeItems = (resumeRow?.items || []).filter(item => !isHiddenByMap(item, hiddenCWMap, false));
 			const resumeItemIds = new Set(resumeItems.map(item => item.Id));
 
 			result = allRowData
@@ -607,7 +597,7 @@ const Browse = ({
 						return {...row, items: resumeItems};
 					}
 					if (row.id === 'nextup') {
-						const filteredItems = row.items.filter(item => !resumeItemIds.has(item.Id) && !isSeriesHiddenFromNextUp(item, hiddenNUMap) && !isItemHiddenFromCW(item, hiddenCWMap));
+						const filteredItems = row.items.filter(item => !resumeItemIds.has(item.Id) && !isHiddenByMap(item, hiddenNUMap, true));
 						return filteredItems.length > 0 ? {...row, items: filteredItems} : null;
 					}
 					return row;

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -38,6 +38,9 @@ const STORAGE_KEY_BROWSE = 'browse_cache_v2';
 let cachedRowData = null;
 let cachedLibraries = null;
 let cachedFeaturedItems = null;
+let cacheTimestamp = null;
+
+let lastFocusState = null;
 
 const parseHiddenMap = (val) => {
 	if (!val) return {};
@@ -54,6 +57,9 @@ const isHiddenByMap = (item, hiddenMap, seriesOnly) => {
 	if (!key || !hiddenMap[key]) return false;
 	// Hide timestamps are stored as ISO strings, so parse before comparing.
 	const hideTimeMs = Date.parse(hiddenMap[key]);
+	// An unparseable hide timestamp can't be reasoned about; treat it as not hidden
+	// rather than hiding the item permanently (NaN comparisons below are always false).
+	if (!Number.isFinite(hideTimeMs)) return false;
 	const lastPlayed = item.UserData?.LastPlayedDate;
 	if (lastPlayed) {
 		const lastPlayedMs = Date.parse(lastPlayed);
@@ -61,9 +67,6 @@ const isHiddenByMap = (item, hiddenMap, seriesOnly) => {
 	}
 	return true;
 };
-let cacheTimestamp = null;
-
-let lastFocusState = null;
 
 const EXCLUDED_COLLECTION_TYPES = ['boxsets', 'books', 'musicvideos', 'homevideos', 'photos'];
 
@@ -594,7 +597,7 @@ const Browse = ({
 			result = allRowData
 				.map(row => {
 					if (row.id === 'resume') {
-						return {...row, items: resumeItems};
+						return resumeItems.length > 0 ? {...row, items: resumeItems} : null;
 					}
 					if (row.id === 'nextup') {
 						const filteredItems = row.items.filter(item => !resumeItemIds.has(item.Id) && !isHiddenByMap(item, hiddenNUMap, true));


### PR DESCRIPTION
# Pull Request

## Summary
Implements dashboard filtering for hidden Continue Watching and Next Up items on the Smart-TV client.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/182

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added `hiddenContinueWatchingItems` and `hiddenNextUpSeries` to `SettingsContext` syncable settings keys and default properties mapping.
- Implemented dashboard row filters in `Browse.js` that parse hidden item/series JSON mappings and filter items out of Continue Watching and Next Up rows.
- Re-trigger filtered rows updates when hidden settings change.


## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Needs proper device testing

### Test Steps
1. Launch the client and fetch synced settings from server.
2. Verify Continue Watching row filters hidden series/movies out correctly.
3. Verify Next Up row filters hidden series out correctly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
