### PR TITLE
Align homerowsstyle keys with core/base

### DIFF
--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -112,7 +112,7 @@ const defaultSettings = {
 	useSeriesThumbnails: false,
 	homeRowsPosterSize: 'default',
 	homeRowsImageType: 'poster',
-	homeRowsStyle: 'modern',
+	homeRowsStyle: 'v2',
 	homeRowOverlay: 'off',
 	folderViewMode: 'local',
 	excludedGenres: [],
@@ -230,7 +230,7 @@ const mergeHomeRows = (rows) => {
 	return merged;
 };
 
-const normalizeHomeRowsStyle = (value) => (value === 'classic' || value === 'modern' ? value : 'modern');
+const normalizeHomeRowsStyle = (value) => (value === 'v1' || value === 'v2' ? value : 'v2');
 
 const normalizeGuid = (id) => {
 	if (!id || typeof id !== 'string') return id;
@@ -397,7 +397,7 @@ export function SettingsProvider({children}) {
 					migrated = true;
 				}
 				if (!hasExplicitHomeRowsStyle) {
-					stored.homeRowsStyle = 'modern';
+					stored.homeRowsStyle = 'v2';
 					migrated = true;
 				} else {
 					const normalizedStyle = normalizeHomeRowsStyle(stored.homeRowsStyle);

--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -230,7 +230,11 @@ const mergeHomeRows = (rows) => {
 	return merged;
 };
 
-const normalizeHomeRowsStyle = (value) => (value === 'v1' || value === 'v2' ? value : 'v2');
+const normalizeHomeRowsStyle = (value) => {
+	if (value === 'classic') return 'v1';
+	if (value === 'modern') return 'v2';
+	return value === 'v1' || value === 'v2' ? value : 'v2';
+};
 
 const normalizeGuid = (id) => {
 	if (!id || typeof id !== 'string') return id;

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -448,7 +448,7 @@ const Browse = ({
 		};
 	}, [activeTheme]);
 
-	const useModernRows = settings.homeRowsStyle !== 'classic';
+	const useModernRows = settings.homeRowsStyle !== 'v1';
 	const RowComponent = useModernRows ? ModernMediaRow : ClassicMediaRow;
 	const showTopInfoArea = !useModernRows;
 

--- a/packages/app/src/views/Settings/Settings.js
+++ b/packages/app/src/views/Settings/Settings.js
@@ -323,8 +323,8 @@ const getImageTypeOptions = () => [
 ];
 
 const getHomeRowsStyleOptions = () => [
-	{ value: 'modern', label: $L('Modern') },
-	{ value: 'classic', label: $L('Classic') }
+	{ value: 'v2', label: $L('Modern') },
+	{ value: 'v1', label: $L('Classic') }
 ];
 
 const getHomeRowSortOptions = () => [


### PR DESCRIPTION
# Pull Request

## Summary
Core/base have homerowsstyle keys as v1/v2, but smarttv had classic/modern, so syncing with moonbase wasn't working properly

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- change keys from classic/modern to v1/v2
- keep label as classic/modern
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
