### PR TITLE
adjust sidebar gradient based on opacity setting

### DIFF
--- a/packages/app/src/components/Sidebar/Sidebar.js
+++ b/packages/app/src/components/Sidebar/Sidebar.js
@@ -74,12 +74,14 @@ const Sidebar = ({
 
 	const navStyle = useMemo(() => {
 		let navbarColor = activeTheme.transparentNavbarSurface ? 'transparent' : `linear-gradient(to right, ${toCssColorWithAlpha(activeTheme.colors.surface, 0.96)}, ${toCssColorWithAlpha(activeTheme.colors.surface, 0.88)}, ${toCssColorWithAlpha(activeTheme.colors.surface, 0.66)}, transparent)`;
-		const c1 = toSafeCssColorWithAlpha(settings.navbarColor, settings.navbarOpacity/100);
-		const c2 = toSafeCssColorWithAlpha(settings.navbarColor, settings.navbarOpacity/105);
-		const c3 = toSafeCssColorWithAlpha(settings.navbarColor, settings.navbarOpacity/110);
-		const c4 = toSafeCssColorWithAlpha(settings.navbarColor, settings.navbarOpacity/115);
+		let normalizedNavbarOpacity = settings.navbarOpacity / 100;
+		const c1 = toSafeCssColorWithAlpha(settings.navbarColor, Math.pow(normalizedNavbarOpacity, 0.25));
+		const c2 = toSafeCssColorWithAlpha(settings.navbarColor, normalizedNavbarOpacity);
+		const c3 = toSafeCssColorWithAlpha(settings.navbarColor, Math.pow(normalizedNavbarOpacity, 2.0));
+		const c4 = toSafeCssColorWithAlpha(settings.navbarColor, Math.pow(normalizedNavbarOpacity, 4.0));
+		const c5 = normalizedNavbarOpacity < 1 ? ", transparent" : "";
 		if (c1 && c2 && c3 && c4) {
-			navbarColor = `linear-gradient(to right, ${c1}, ${c1}, ${c2}, ${c3}, ${c4}, transparent)`;
+			navbarColor = `linear-gradient(to right, ${c1}, ${c1}, ${c2}, ${c3}, ${c4}${c5})`;
 		}
 		return {
 			background: expanded ? navbarColor : 'transparent',


### PR DESCRIPTION
# Pull Request

## Summary
Radical Muffin Man, you and I have been compromising for too long. We should both be happy. 

It's become clear to me that you like more gradient on your sidebar, whereas I prefer a solid sidebar. To compromise, you pushed the gradient out so most of the sidebar would follow the opacity, and then the edge would drop off in a gradient. 

My new proposal is this: let the opacity define the gradient. 100% opacity? No gradient. 90%? Slight gradient at the edge. 50%? Complete gradient. 0%? Completely transparent (below 50 is not even currently supported on core tv/desktop, it stops at 50%)

This way I could set 100% and have a solid sidebar, and you could do 50 or 75% and have more of a gradient that you like. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Adjust gradient calculation for sidebar
- 
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="3829" height="1982" alt="Screenshot_20260711_150342" src="https://github.com/user-attachments/assets/ffa2f0db-1cba-4735-ad30-7d7b5038a2e2" />
<img width="3829" height="1982" alt="Screenshot_20260711_150327" src="https://github.com/user-attachments/assets/2ed0c4b9-e912-4c4a-a37d-263446f5e328" />
<img width="3829" height="1982" alt="Screenshot_20260711_150320" src="https://github.com/user-attachments/assets/2f649b5d-63dc-4a87-b599-6c9775c12300" />
<img width="3829" height="1982" alt="Screenshot_20260711_150313" src="https://github.com/user-attachments/assets/74006cfd-8041-4f6e-a9c9-1c5b306c6821" />
<img width="3829" height="1982" alt="Screenshot_20260711_150254" src="https://github.com/user-attachments/assets/72e250ea-b1e4-41b7-b566-f55e1cf858c9" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
