### PR TITLE
fix: add catch fallback to getRandomItems API query on home page load

### DIFF
--- a/packages/app/src/components/MediaRow/ModernMediaRow.js
+++ b/packages/app/src/components/MediaRow/ModernMediaRow.js
@@ -38,7 +38,7 @@ const ModernMediaRow = ({
 	const keyPrefix = rowId || title || rowIndex || '';
 
 	useEffect(() => {
-		const el = rowElementRef.current;
+		const el = document.querySelector(`[data-row-index="${rowIndex}"]`) || rowElementRef.current;
 		registerRowRef?.(rowIndex, el);
 		return () => registerRowRef?.(rowIndex, null);
 	}, [rowIndex, registerRowRef]);
@@ -100,10 +100,10 @@ const ModernMediaRow = ({
 
 	const handleBlur = useCallback((e) => {
 		const nextTarget = e.relatedTarget;
-		const rowNode = rowElementRef.current;
-		if (rowNode && nextTarget && rowNode.contains(nextTarget)) return;
+		const rowNode = document.querySelector(`[data-row-index="${rowIndex}"]`) || rowElementRef.current;
+		if (rowNode && nextTarget && typeof rowNode.contains === 'function' && rowNode.contains(nextTarget)) return;
 		setFocusedItemId(null);
-	}, []);
+	}, [rowIndex]);
 
 	const handleFocusedChange = useCallback((itemId) => {
 		setFocusedItemId(itemId || null);

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -940,7 +940,7 @@ const Browse = ({
 							api.getResumeItems(),
 							api.getNextUp(),
 							api.getUserConfiguration().catch(() => null),
-							api.getRandomItems(settings.featuredContentType, settings.featuredItemCount),
+							api.getRandomItems(settings.featuredContentType, settings.featuredItemCount).catch(() => null),
 							settings.mergeContinueWatchingNextUp ? api.getItems({
 								IncludeItemTypes: 'Episode',
 								Filters: 'IsPlayed',


### PR DESCRIPTION
This prevents slow database scans from timing out and crashing the entire home page loading sequence.

# Pull Request

## Summary
This PR resolves a critical startup crash on the browse/home page. 

During startup, the client queries for random media items to display as the featured background card at the top of the homepage (`api.getRandomItems(...)`). On slower servers (like home NAS setups) or large databases, this query frequently takes more than 15 seconds to run, exceeding the client-side timeout limit.

Since this call was previously part of the main `Promise.all` block without a catch fallback, a timeout on the background card query would abort the entire loader promise, causing the homepage to crash and display "No content found" rather than fallback rows.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Browse.js**: Added `.catch(() => null)` to `api.getRandomItems` so that slow random backdrop scans do not block or crash the initial loading of critical homepage elements (such as libraries, "Continue Watching", and "Next Up").

- **ModernMediaRow.js**: Replaced the React component instance ref wrapper check with a native DOM element query (`document.querySelector`) and added a fallback type check. This resolves the uncaught `TypeError: rowNode.contains is not a function` crash that was being thrown in the console whenever focus left a row.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open the emulator version of smart tv in browser
2. Have the home page load :)

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="2560" height="1424" alt="2026-07-15_10-09-41_chrome" src="https://github.com/user-attachments/assets/263e6c80-26ac-4ff9-b592-e334303a1308" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
