### PR TITLE
map sinceyouwatched rows correctly to moonbase

### DIFF
--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -26,11 +26,11 @@ const DEFAULT_HOME_ROWS = [
 	{id: 'imdb-popular-tv', name: 'IMDb Most Popular TV Shows', enabled: false, order: 18},
 	{id: 'imdb-lowest-rated', name: 'IMDb Lowest Rated Movies', enabled: false, order: 19},
 	{id: 'imdb-top-english', name: 'IMDb Top Rated English Movies', enabled: false, order: 20},
-	{id: 'since-you-watched-1', name: 'Since You Watched Row 1', enabled: false, order: 21},
-	{id: 'since-you-watched-2', name: 'Since You Watched Row 2', enabled: false, order: 22},
-	{id: 'since-you-watched-3', name: 'Since You Watched Row 3', enabled: false, order: 23},
-	{id: 'since-you-watched-4', name: 'Since You Watched Row 4', enabled: false, order: 24},
-	{id: 'since-you-watched-5', name: 'Since You Watched Row 5', enabled: false, order: 25},
+	{id: 'sinceyouwatched1', name: 'Since You Watched Row 1', enabled: false, order: 21},
+	{id: 'sinceyouwatched2', name: 'Since You Watched Row 2', enabled: false, order: 22},
+	{id: 'sinceyouwatched3', name: 'Since You Watched Row 3', enabled: false, order: 23},
+	{id: 'sinceyouwatched4', name: 'Since You Watched Row 4', enabled: false, order: 24},
+	{id: 'sinceyouwatched5', name: 'Since You Watched Row 5', enabled: false, order: 25},
 	{id: 'rewatch', name: 'Rewatch', enabled: false, order: 26},
 	{id: 'playlists', name: 'Playlists', enabled: false, order: 27},
 	{id: 'audioartists', name: 'Music Artists', enabled: false, order: 28},
@@ -267,12 +267,7 @@ const TV_TO_SERVER_ROW = {
 	'imdb-popular-movies': 'imdb_most_popular_movies',
 	'imdb-popular-tv': 'imdb_most_popular_tv_shows',
 	'imdb-lowest-rated': 'imdb_lowest_rated_movies',
-	'imdb-top-english': 'imdb_top_english_movies',
-	'since-you-watched-1': 'sinceyouwatched1',
-	'since-you-watched-2': 'sinceyouwatched2',
-	'since-you-watched-3': 'sinceyouwatched3',
-	'since-you-watched-4': 'sinceyouwatched4',
-	'since-you-watched-5': 'sinceyouwatched5'
+	'imdb-top-english': 'imdb_top_english_movies'
 };
 const SERVER_TO_TV_ROW = {
 	'latestmedia': 'latest-media',
@@ -293,12 +288,7 @@ const SERVER_TO_TV_ROW = {
 	'imdb_most_popular_movies': 'imdb-popular-movies',
 	'imdb_most_popular_tv_shows': 'imdb-popular-tv',
 	'imdb_lowest_rated_movies': 'imdb-lowest-rated',
-	'imdb_top_english_movies': 'imdb-top-english',
-	'sinceyouwatched1': 'since-you-watched-1',
-	'sinceyouwatched2': 'since-you-watched-2',
-	'sinceyouwatched3': 'since-you-watched-3',
-	'sinceyouwatched4': 'since-you-watched-4',
-	'sinceyouwatched5': 'since-you-watched-5'
+	'imdb_top_english_movies': 'imdb-top-english'
 };
 
 export {TV_TO_SERVER_ROW};

--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -267,7 +267,12 @@ const TV_TO_SERVER_ROW = {
 	'imdb-popular-movies': 'imdb_most_popular_movies',
 	'imdb-popular-tv': 'imdb_most_popular_tv_shows',
 	'imdb-lowest-rated': 'imdb_lowest_rated_movies',
-	'imdb-top-english': 'imdb_top_english_movies'
+	'imdb-top-english': 'imdb_top_english_movies',
+	'since-you-watched-1': 'sinceyouwatched1',
+	'since-you-watched-2': 'sinceyouwatched2',
+	'since-you-watched-3': 'sinceyouwatched3',
+	'since-you-watched-4': 'sinceyouwatched4',
+	'since-you-watched-5': 'sinceyouwatched5'
 };
 const SERVER_TO_TV_ROW = {
 	'latestmedia': 'latest-media',
@@ -288,7 +293,12 @@ const SERVER_TO_TV_ROW = {
 	'imdb_most_popular_movies': 'imdb-popular-movies',
 	'imdb_most_popular_tv_shows': 'imdb-popular-tv',
 	'imdb_lowest_rated_movies': 'imdb-lowest-rated',
-	'imdb_top_english_movies': 'imdb-top-english'
+	'imdb_top_english_movies': 'imdb-top-english',
+	'sinceyouwatched1': 'since-you-watched-1',
+	'sinceyouwatched2': 'since-you-watched-2',
+	'sinceyouwatched3': 'since-you-watched-3',
+	'sinceyouwatched4': 'since-you-watched-4',
+	'sinceyouwatched5': 'since-you-watched-5'
 };
 
 export {TV_TO_SERVER_ROW};

--- a/packages/app/src/services/homeRecommendations.js
+++ b/packages/app/src/services/homeRecommendations.js
@@ -363,7 +363,7 @@ export async function loadSinceYouWatchedRows(api, settings, enabledIndexes, onl
 				const onlineItems = await getOnlineRecommendations(settings, seed).catch(() => []);
 				if (onlineItems.length) {
 					return {
-						id: `since-you-watched-${idx}`,
+						id: `sinceyouwatched${idx}`,
 						seedName: seed.Name || '',
 						items: onlineItems,
 						isSeerr: true
@@ -378,7 +378,7 @@ export async function loadSinceYouWatchedRows(api, settings, enabledIndexes, onl
 			}).catch(() => []);
 			if (!items.length) return null;
 			return {
-				id: `since-you-watched-${idx}`,
+				id: `sinceyouwatched${idx}`,
 				seedName: seed.Name || '',
 				items
 			};

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -881,7 +881,7 @@ const Browse = ({
 			// Recommendation rows are only built by fetchAllData, so treat an enabled one
 			// as dynamic config. Otherwise enabling it shows nothing until the cache expires.
 			const hasEnabledRecommendationRow = homeRowsConfig.some(
-				(row) => row.enabled && (row.id.startsWith('since-you-watched-') || row.id === 'rewatch')
+				(row) => row.enabled && (row.id.startsWith('sinceyouwatched') || row.id === 'rewatch')
 			);
 			const hasEnabledMediaSectionRow = homeRowsConfig.some(
 				(row) => row.enabled && ['audioartists', 'audioalbums', 'audioplaylists', 'resumeaudio', 'activerecordings'].includes(row.id)
@@ -1283,8 +1283,8 @@ const Browse = ({
 					const recordingsEnabled = homeRowsConfig.some((row) => row.enabled && row.id === 'activerecordings');
 					const enabledPluginSections = (settings.pluginSections || []).filter((section) => section.enabled);
 					const sinceYouWatchedIndexes = homeRowsConfig
-						.filter((row) => row.enabled && row.id.startsWith('since-you-watched-'))
-						.map((row) => parseInt(row.id.replace('since-you-watched-', ''), 10))
+						.filter((row) => row.enabled && row.id.startsWith('sinceyouwatched'))
+						.map((row) => parseInt(row.id.replace('sinceyouwatched', ''), 10))
 						.filter((idx) => idx >= 1)
 						.sort((a, b) => a - b);
 					const rewatchEnabled = homeRowsConfig.some((row) => row.enabled && row.id === 'rewatch');

--- a/packages/app/src/views/Settings/Settings.js
+++ b/packages/app/src/views/Settings/Settings.js
@@ -1598,7 +1598,7 @@ const Settings = ({ onBack, onLibrariesChanged, panelMode }) => {
 			{renderOptionItem('homeRowsPosterSize', $L('Home Row Card Display Size'), getPosterSizeOptions(), $L('Default'), 'aspectratio')}
 			{renderOptionItem('homeRowOverlay', $L('Home Row Info Overlay'), getHomeRowOverlayOptions(), $L('Off'), 'info')}
 			{renderNavItem('homeRows', $L('Home Sections'), $L('Reorder and toggle home rows'), openHomeRows, 'list')}
-			{(settings.homeRows || []).some((row) => row.enabled && row.id.startsWith('since-you-watched-')) && (
+			{(settings.homeRows || []).some((row) => row.enabled && row.id.startsWith('sinceyouwatched')) && (
 				<>
 					{renderOptionItem('sinceYouWatchedSource', $L('Since You Watched Source'), getSinceYouWatchedSourceOptions(), $L('Local'), 'browser')}
 					{renderOptionItem('sinceYouWatchedSourceItem', $L('Since You Watched Seed'), getSinceYouWatchedSourceItemOptions(), $L('Recently Watched'), 'playcircle')}


### PR DESCRIPTION
# Pull Request

## Summary
Map the row title for sinceyouwatched rows so it syncs with moonbase correctly

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- map since-you-watched-1 on tv to sinceyouwatched1 on server
- same thing but other way around
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
