### PR TITLE
feature-ui - Port "Read More" behaviour to Smart-TV

### DIFF
--- a/packages/app/src/views/Details/ModernDetailContent.js
+++ b/packages/app/src/views/Details/ModernDetailContent.js
@@ -62,11 +62,12 @@ const ModernDetailContent = (props) => {
 	const [isExpanded, setIsExpanded] = useState(false);
 	const descriptionRef = useRef(null);
 
-	// Reset expanded state when item changes
+	// Reset expanded state when navigating to a different item. Keyed on the id so an
+	// in-place update to the same item doesn't collapse the text.
 	useEffect(() => {
 		setIsExpanded(false);
 		setCanToggle(false);
-	}, [item]);
+	}, [item?.Id]);
 
 	// Detect if description text overflows 4 lines
 	useEffect(() => {
@@ -538,7 +539,7 @@ const ModernDetailContent = (props) => {
 									<p ref={descriptionRef} className={`${css.overview} ${!isExpanded ? css.overviewCollapsed : ''}`}>
 										{item.Overview}
 									</p>
-									{canToggle && !isExpanded && <div className={css.readMoreBtn}>{$L('Read More')}</div>}
+									{canToggle && <div className={css.readMoreBtn}>{isExpanded ? $L('Read Less') : $L('Read More')}</div>}
 								</SpottableDiv>
 							)}
 						</div>

--- a/packages/app/src/views/Details/ModernDetailContent.js
+++ b/packages/app/src/views/Details/ModernDetailContent.js
@@ -58,6 +58,28 @@ const ModernDetailContent = (props) => {
 	const played = item.UserData?.Played;
 	const isFavorite = item.UserData?.IsFavorite;
 
+	const [canToggle, setCanToggle] = useState(false);
+	const [isExpanded, setIsExpanded] = useState(false);
+	const descriptionRef = useRef(null);
+
+	// Reset expanded state when item changes
+	useEffect(() => {
+		setIsExpanded(false);
+		setCanToggle(false);
+	}, [item]);
+
+	// Detect if description text overflows 4 lines
+	useEffect(() => {
+		const el = descriptionRef.current;
+		if (el && !isExpanded) {
+			setCanToggle(el.scrollHeight > el.clientHeight);
+		}
+	}, [item?.Overview, isExpanded]);
+
+	const handleToggleExpand = useCallback(() => {
+		setIsExpanded(prev => !prev);
+	}, []);
+
 	const scrollToRef = useRef(null);
 	const handleScrollTo = useCallback((fn) => {
 		scrollToRef.current = fn;
@@ -507,7 +529,18 @@ const ModernDetailContent = (props) => {
 							)}
 							{!isPerson && <RatingsRow item={item} serverUrl={effectiveServerUrl} pluginEnabled={settings.useMoonfinPlugin && settings.mdblistEnabled !== false} />}
 							{tagline && <div className={css.tagline}>{tagline}</div>}
-							{item.Overview && <p className={css.overview}>{item.Overview}</p>}
+							{item.Overview && (
+								<SpottableDiv
+									className={`${css.descriptionContainer} ${canToggle ? css.descriptionContainerSpottable : ''}`}
+									onClick={canToggle ? handleToggleExpand : null}
+									spotlightDisabled={!canToggle}
+								>
+									<p ref={descriptionRef} className={`${css.overview} ${!isExpanded ? css.overviewCollapsed : ''}`}>
+										{item.Overview}
+									</p>
+									{canToggle && !isExpanded && <div className={css.readMoreBtn}>{$L('Read More')}</div>}
+								</SpottableDiv>
+							)}
 						</div>
 						{renderUpNext()}
 					</div>

--- a/packages/app/src/views/Details/ModernDetailContent.module.less
+++ b/packages/app/src/views/Details/ModernDetailContent.module.less
@@ -131,10 +131,49 @@
 .overview {
 	font-size: 26px;
 	line-height: 1.5;
-	max-width: 900px;
+	max-width: 100%;
 	opacity: 0.92;
 	margin: 0;
 }
+
+.overviewCollapsed {
+	display: -webkit-box;
+	-webkit-line-clamp: 4;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.descriptionContainer {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 24px;
+	border-radius: 16px;
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	background: rgba(255, 255, 255, 0.03);
+	max-width: 900px;
+	box-sizing: border-box;
+	transition: border-color 0.15s ease, background-color 0.15s ease, transform 0.15s ease;
+	outline: none;
+}
+
+.descriptionContainerSpottable {
+	cursor: pointer;
+}
+
+.descriptionContainerSpottable:focus {
+	border-color: rgba(255, 255, 255, 0.35);
+	background: rgba(255, 255, 255, 0.06);
+	transform: scale(1.01);
+}
+
+.readMoreBtn {
+	color: #ff5b5b;
+	font-weight: 600;
+	font-size: 22px;
+	align-self: flex-start;
+}
+
 
 .icon {
 	width: 32px;

--- a/packages/app/src/views/Details/ModernDetailContent.module.less
+++ b/packages/app/src/views/Details/ModernDetailContent.module.less
@@ -174,7 +174,6 @@
 	align-self: flex-start;
 }
 
-
 .icon {
 	width: 32px;
 	height: 32px;


### PR DESCRIPTION
# Pull Request

## Summary
Implements a collapsible text container ("Read More" link) for long media descriptions (longer than 4 lines) on the Smart-TV details page, matching the visual grouping and behavior of the core client.

## Related Issues
Link related issues or tickets separated by commas.

Discord feedback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added React state `isExpanded` and `canToggle` to track expanded/collapsed visual state and overflow status.
- Implemented React `useEffect` hook to measure paragraph `scrollHeight` vs `clientHeight` when collapsed to dynamically detect text overflow (> 4 lines).
- Wrapped description block in an Enact sandstone `SpottableDiv` with `spotlightDisabled={!canToggle}` so only overflowing descriptions are focusable via D-pad remote.
- Created `.descriptionContainer` styles (thin border, slight background, padding) for visual grouping.
- Created `.overviewCollapsed` class using line-clamp (`-webkit-line-clamp: 4`) to truncate long descriptions.
- Added scale transitions and highlights for `.descriptionContainerSpottable` focus state, and styled the `#ff5b5b` colored "Read More" trigger button.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a media item with a short description (< 4 lines) and verify that it renders fully, has no focus states, and shows no "Read More" button.
2. Navigate to a media item with a long description (> 4 lines) and verify that it is clamped to 4 lines with a trailing ellipsis and a "Read More" button.
3. Move remote focus to the description box (showing highlight/scale transition) and press OK/Enter to fully expand it.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

https://github.com/user-attachments/assets/661368f4-56a4-4cde-9e31-e5012984f111

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
