### PR TITLE
Fix: Back after playback returns Home instead of the previous view

### DIFF
--- a/packages/app/src/App/App.js
+++ b/packages/app/src/App/App.js
@@ -720,9 +720,18 @@ const AppContent = (props) => {
 		setPlayingItem(null);
 		setPlaybackOptions(null);
 		setIsResume(false);
-		handleBack();
+		// Return to the previous panel WITHOUT clearing the DETAILS/Seerr item breadcrumb.
+		// handleBack() resets detailsItemStackRef/seerrItemStackRef, which would lose the
+		// series -> season -> episode trail and make the next Back jump out of the show to Home.
+		if (panelHistory.length > 0) {
+			const prevPanel = panelHistory[panelHistory.length - 1];
+			setPanelHistory(prev => prev.slice(0, -1));
+			setPanelIndex(prevPanel);
+		} else if (panelIndex > PANELS.BROWSE) {
+			setPanelIndex(PANELS.BROWSE);
+		}
 		window.dispatchEvent(new CustomEvent('moonfin:browseRefresh'));
-	}, [handleBack]);
+	}, [panelHistory, panelIndex]);
 
 	const handleOpenSearch = useCallback(() => {
 		navigateTo(PANELS.SEARCH);


### PR DESCRIPTION
# Pull Request

## Summary
Fixes navigation after playback: pressing **Back** when an episode finishes (or is exited) returned to the Home grid instead of the season/series you were in, forcing you to re-enter the show for every episode. Plain folder navigation (without starting playback) was unaffected — only playback triggered it.

## Related Issues
N/A — no existing tracking issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- `handlePlayerEnd()` no longer calls `handleBack()`, which unconditionally reset `detailsItemStackRef` / `seerrItemStackRef` — the in-panel breadcrumb used for series → season → episode navigation.
- Instead it returns to the previous panel by popping `panelHistory` directly (the same panel step `handleBack()` performs), leaving the item stacks intact so the breadcrumb survives playback.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
The bug is reliably reproducible on a physical Samsung S95B (Tizen). The change is a minimal, self-contained adjustment to the shared panel-navigation flow.

- [ ] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [x] Not tested (explain why): I couldn't runtime-verify a custom sideloaded build (Samsung dev-cert / signing constraints on my end). The fix is verified by tracing the `panelHistory` / `detailsItemStackRef` logic in `App.js`. Happy to adjust if a maintainer can run it.

### Test Steps
1. Open a series → a season → start an episode.
2. Finish the episode (or press Back to exit the player).
3. Press Back — before: jumps to the Home grid; after: returns to the season, and Back again steps season → series → out as expected.

## Screenshots (if applicable)
N/A — navigation behavior only, no visual change.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
