### PR TITLE
fix(browse) - preserve vertical clearance for top navbar

### DIFF
--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -790,7 +790,8 @@ const Browse = ({
 			return;
 		}
 
-		container.scrollTop = targetRow.offsetTop;
+		const topbarOffset = settings.navbarPosition !== 'left' ? 130 : 0;
+		container.scrollTop = Math.max(0, targetRow.offsetTop - topbarOffset);
 
 		if (thenFocus) {
 			let attempts = 0;
@@ -805,7 +806,7 @@ const Browse = ({
 			};
 			scrollTimeoutRef.current = setTimeout(tryFocus, 0);
 		}
-	}, [focusRow]);
+	}, [focusRow, settings.navbarPosition]);
 
 	const handleNavigateUp = useCallback((fromRowIndex) => {
 		if (fromRowIndex === 0) {

--- a/packages/app/src/views/Browse/Browse.module.less
+++ b/packages/app/src/views/Browse/Browse.module.less
@@ -1278,7 +1278,7 @@
 	flex: 1;
 	overflow-y: auto;
 	overflow-x: hidden;
-	padding: 0 0 60px 0;
+	padding: 0 0 60vh 0;
 	scrollbar-width: none;
 	position: relative;
 
@@ -1292,7 +1292,9 @@
 }
 
 .topbarOffset .contentRows {
-	padding-top: 75px;
+	padding-top: 130px;
+	padding-bottom: 60vh;
+	scroll-padding-top: 130px;
 }
 
 .sidebarOffset .detailSection {
@@ -1304,8 +1306,12 @@
 }
 
 /* Rows mode - position rows below detail section */
-.rowsMode {
+.sidebarOffset .contentRows.rowsMode {
 	padding-top: 0;
+}
+
+.topbarOffset .contentRows.rowsMode {
+	padding-top: 130px;
 }
 
 .empty {


### PR DESCRIPTION
# Pull Request

## Summary
Fix layout overlap issue in Moonfin Smart-TV where navigating down through home rows when **Expanded Home Rows** (`fullScreenRows`) is **OFF** causes row titles and media cards to scroll underneath and overlap the floating Top Navbar.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Browse.module.less**: Preserved topbar padding clearance (`padding-top: 130px;` and `scroll-padding-top: 130px;`) in `.topbarOffset .contentRows.rowsMode` so home rows do not collapse under Top Navbar. Added `padding-bottom: 60vh;` so the final row has sufficient scrollable height (`scrollHeight`) to align cleanly below the Top Navbar.
- **Browse.js**: Updated **scrollToRow** to subtract `topbarOffset` (`130px`) when navbar is at the top (`settings.navbarPosition !== 'left'`), and added `settings.navbarPosition` to `useCallback` dependencies.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin Smart-TV with Top Navbar enabled.
2. In **Settings > Home Rows**, turn **Expanded Home Rows** to **OFF**.
3. Navigate to the Home screen and scroll down through all home rows (including the final row).
4. Verify that each focused row aligns cleanly `130px` below the Top Navbar without overlapping top navigation buttons or clock.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="2518" height="1206" alt="2026-07-31_16-16-29_brave" src="https://github.com/user-attachments/assets/7015f5f8-8a3a-4b5d-8248-b75f1c230103" />

Home Page:
<img width="2518" height="1206" alt="2026-07-31_16-16-51_brave" src="https://github.com/user-attachments/assets/06dc355f-74b3-4bfd-82b3-ad5709faa3ce" />
<img width="2518" height="1206" alt="2026-07-31_16-17-01_brave" src="https://github.com/user-attachments/assets/8190cd52-a634-444e-8b88-98ac5e48b9ee" />

Padding works on final row:
<img width="2518" height="1206" alt="2026-07-31_16-25-57_brave" src="https://github.com/user-attachments/assets/bc0eef78-dee5-4df0-a18b-9dfe319b2354" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
