### PR TITLE
fix(home): The one about Homescreen Images

### DIFF
--- a/packages/app/src/components/MediaCard/MediaCard.js
+++ b/packages/app/src/components/MediaCard/MediaCard.js
@@ -21,11 +21,12 @@ const toAbsoluteImageUrl = (url, serverUrl) => {
 
 const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusItem, showServerBadge = false, showOverview = false, eagerLoad = false, spotlightId, onSpotlightLeft, onSpotlightRight}) => {
 	const {settings} = useSettings();
-	const isLandscape = cardType === 'landscape';
+	const imageType = settings.homeRowsImageType || 'poster';
+	const isLandscape = cardType === 'landscape' || (cardType === 'portrait' && (imageType === 'thumb' || imageType === 'backdrop' || imageType === 'logo'));
 	// Artists read as circles in the music library. It rides on the square path
 	// since the art is the same 1:1 either way, only the radius differs.
 	const isCircle = cardType === 'circle';
-	const isSquare = isCircle || cardType === 'square' || (cardType === 'portrait' && (item.Type === 'MusicAlbum' || item.Type === 'MusicArtist' || item.Type === 'Audio'));
+	const isSquare = isCircle || cardType === 'square' || (cardType === 'portrait' && !isLandscape && (item.Type === 'MusicAlbum' || item.Type === 'MusicArtist' || item.Type === 'Audio'));
 	const focusTimeoutRef = useRef(null);
 
 	useEffect(() => {
@@ -41,8 +42,17 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 	}, [item._serverUrl, serverUrl]);
 
 	const imageUrl = useMemo(() => {
-		const imageType = settings.homeRowsImageType || 'poster';
 		const providerIds = item.ProviderIds || {};
+		const externalPoster = item._externalPosterUrl ||
+			providerIds.SeerrPoster ||
+			providerIds.SonarrPoster ||
+			providerIds.RadarrPoster ||
+			providerIds.LidarrPoster ||
+			providerIds.ReadarrPoster;
+
+		if (externalPoster && (item._external || !item.ImageTags?.Primary)) {
+			return toAbsoluteImageUrl(externalPoster, itemServerUrl);
+		}
 
 		if (item.Type === 'Genre' && item._representative) {
 			const rep = item._representative;
@@ -58,18 +68,80 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 			}
 		}
 
-		if (isLandscape && item.Type === 'Episode') {
-			if (settings.useSeriesThumbnails && item.SeriesId && item.SeriesPrimaryImageTag) {
-				return getImageUrl(itemServerUrl, item.SeriesId, 'Primary', {maxHeight: 300, quality: 80});
+		if (imageType === 'backdrop') {
+			if (item.BackdropImageTags?.length > 0) {
+				return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
 			}
-			if (item.ImageTags?.Primary) {
-				return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxWidth: 400, quality: 80});
+			if (item.ParentBackdropItemId) {
+				return getImageUrl(itemServerUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 400, quality: 80});
+			}
+			if (item.ImageTags?.Thumb) {
+				return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
+			}
+		} else if (imageType === 'thumb') {
+			if (item.ImageTags?.Thumb) {
+				return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
 			}
 			if (item.ParentThumbItemId) {
 				return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
 			}
-			if (item.ParentBackdropItemId) {
-				return getImageUrl(itemServerUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 400, quality: 80});
+			if (item.BackdropImageTags?.length > 0) {
+				return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
+			}
+		} else if (imageType === 'logo') {
+			if (item.ImageTags?.Logo) {
+				return getImageUrl(itemServerUrl, item.Id, 'Logo', {maxWidth: 400, quality: 80});
+			}
+			if (item.ParentLogoItemId) {
+				return getImageUrl(itemServerUrl, item.ParentLogoItemId, 'Logo', {maxWidth: 400, quality: 80});
+			}
+		}
+
+		if (isLandscape) {
+			if (item.Type === 'Episode') {
+				const seriesId = item.SeriesId || item.SeriesPrimaryImageItemId || item.ParentPrimaryImageItemId;
+				if (settings.useSeriesThumbnails) {
+					if (item.ParentThumbItemId) {
+						return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
+					}
+					if (seriesId) {
+						return getImageUrl(itemServerUrl, seriesId, 'Thumb', {maxWidth: 400, quality: 80});
+					}
+				}
+				if (item.ImageTags?.Thumb) {
+					return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
+				}
+				if (item.ParentThumbItemId) {
+					return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
+				}
+				if (item.BackdropImageTags?.length > 0) {
+					return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
+				}
+				if (item.ParentBackdropItemId) {
+					return getImageUrl(itemServerUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 400, quality: 80});
+				}
+				if (item.ImageTags?.Primary) {
+					return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxWidth: 400, quality: 80});
+				}
+				if (seriesId) {
+					return getImageUrl(itemServerUrl, seriesId, 'Primary', {maxHeight: 300, quality: 80});
+				}
+			} else {
+				if (item.ImageTags?.Thumb) {
+					return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
+				}
+				if (item.ParentThumbItemId) {
+					return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
+				}
+				if (item.BackdropImageTags?.length > 0) {
+					return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
+				}
+				if (item.ParentBackdropItemId) {
+					return getImageUrl(itemServerUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 400, quality: 80});
+				}
+				if (item.ImageTags?.Primary) {
+					return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 300, quality: 80});
+				}
 			}
 		}
 
@@ -104,18 +176,16 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 			return getImageUrl(itemServerUrl, item.AlbumId, 'Primary', {maxHeight: 300, quality: 80});
 		}
 
-		const externalPoster = item._externalPosterUrl ||
-			providerIds.SeerrPoster ||
-			providerIds.SonarrPoster ||
-			providerIds.RadarrPoster ||
-			providerIds.LidarrPoster ||
-			providerIds.ReadarrPoster;
 		if (externalPoster) {
 			return toAbsoluteImageUrl(externalPoster, itemServerUrl);
 		}
 
+		if (item.Id) {
+			return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 300, quality: 80});
+		}
+
 		return null;
-	}, [isLandscape, item.Type, item.ImageTags?.Primary, item.ImageTags?.Thumb, item.ImageTags?.Logo, item.Id, item.ParentThumbItemId, item.ParentBackdropItemId, item.BackdropImageTags, item.ParentLogoItemId, item.AlbumId, item.AlbumPrimaryImageTag, item.SeriesId, item.SeriesPrimaryImageTag, item.ProviderIds, item._externalPosterUrl, itemServerUrl, settings.homeRowsImageType, settings.useSeriesThumbnails, item._representative]);
+	}, [isLandscape, item, itemServerUrl, imageType, settings.useSeriesThumbnails]);
 
 	const handleClick = useCallback(() => {
 		onSelect?.(item);
@@ -180,7 +250,10 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 							loading={eagerLoad ? 'eager' : 'lazy'}
 							width={cardWidth}
 							height={cardHeight}
-							style={imgSizeStyle}
+							style={{
+								...(imgSizeStyle || {}),
+								objectFit: imageType === 'logo' ? 'contain' : 'cover'
+							}}
 						/>
 						{(item?.Type === 'Genre' || item?.Type === 'MusicGenre') && (
 							<>

--- a/packages/app/src/components/MediaCard/MediaCard.js
+++ b/packages/app/src/components/MediaCard/MediaCard.js
@@ -19,14 +19,45 @@ const toAbsoluteImageUrl = (url, serverUrl) => {
 	return `${serverUrl}/${url}`;
 };
 
-const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusItem, showServerBadge = false, showOverview = false, eagerLoad = false, spotlightId, onSpotlightLeft, onSpotlightRight}) => {
+// The wide artwork a row asked for, or null when the item carries none of it. Handing
+// back the url rather than a yes or no is what keeps the card shape and the picture it
+// ends up holding from ever disagreeing.
+const requestedArtwork = (item, imageType, serverUrl) => {
+	if (imageType === 'backdrop') {
+		if (item.BackdropImageTags?.length > 0) {
+			return getImageUrl(serverUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
+		}
+		if (item.ParentBackdropItemId) {
+			return getImageUrl(serverUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 400, quality: 80});
+		}
+		if (item.ImageTags?.Thumb) {
+			return getImageUrl(serverUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
+		}
+	}
+	if (imageType === 'thumb') {
+		if (item.ImageTags?.Thumb) {
+			return getImageUrl(serverUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
+		}
+		if (item.ParentThumbItemId) {
+			return getImageUrl(serverUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
+		}
+		if (item.BackdropImageTags?.length > 0) {
+			return getImageUrl(serverUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
+		}
+	}
+	if (imageType === 'logo') {
+		if (item.ImageTags?.Logo) {
+			return getImageUrl(serverUrl, item.Id, 'Logo', {maxWidth: 400, quality: 80});
+		}
+		if (item.ParentLogoItemId) {
+			return getImageUrl(serverUrl, item.ParentLogoItemId, 'Logo', {maxWidth: 400, quality: 80});
+		}
+	}
+	return null;
+};
+
+const MediaCard = ({item, serverUrl, cardType = 'portrait', rowImageType = 'poster', onSelect, onFocusItem, showServerBadge = false, showOverview = false, eagerLoad = false, spotlightId, onSpotlightLeft, onSpotlightRight}) => {
 	const {settings} = useSettings();
-	const imageType = settings.homeRowsImageType || 'poster';
-	const isLandscape = cardType === 'landscape' || (cardType === 'portrait' && (imageType === 'thumb' || imageType === 'backdrop' || imageType === 'logo'));
-	// Artists read as circles in the music library. It rides on the square path
-	// since the art is the same 1:1 either way, only the radius differs.
-	const isCircle = cardType === 'circle';
-	const isSquare = isCircle || cardType === 'square' || (cardType === 'portrait' && !isLandscape && (item.Type === 'MusicAlbum' || item.Type === 'MusicArtist' || item.Type === 'Audio'));
 	const focusTimeoutRef = useRef(null);
 
 	useEffect(() => {
@@ -41,6 +72,17 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 		return item._serverUrl || serverUrl;
 	}, [item._serverUrl, serverUrl]);
 
+	// The row decides what its cards show, so anywhere else keeps posters. A genre card
+	// draws on one of its own items, so that is where its artwork has to be looked for.
+	const imageType = rowImageType || 'poster';
+	const artworkItem = (item.Type === 'Genre' && item._representative) || item;
+	const rowArtwork = requestedArtwork(artworkItem, imageType, itemServerUrl);
+	const isLandscape = cardType === 'landscape' || (cardType === 'portrait' && Boolean(rowArtwork));
+	// Artists read as circles in the music library. It rides on the square path
+	// since the art is the same 1:1 either way, only the radius differs.
+	const isCircle = cardType === 'circle';
+	const isSquare = isCircle || cardType === 'square' || (cardType === 'portrait' && !isLandscape && (item.Type === 'MusicAlbum' || item.Type === 'MusicArtist' || item.Type === 'Audio'));
+
 	const imageUrl = useMemo(() => {
 		const providerIds = item.ProviderIds || {};
 		const externalPoster = item._externalPosterUrl ||
@@ -54,59 +96,18 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 			return toAbsoluteImageUrl(externalPoster, itemServerUrl);
 		}
 
-		if (item.Type === 'Genre' && item._representative) {
-			const rep = item._representative;
-			const repServerUrl = itemServerUrl;
-			if (imageType === 'thumb' && rep.ImageTags?.Thumb) {
-				return getImageUrl(repServerUrl, rep.Id, 'Thumb', {maxWidth: 400, quality: 80});
-			}
-			if (imageType === 'backdrop' && rep.BackdropImageTags?.length > 0) {
-				return getImageUrl(repServerUrl, rep.Id, 'Backdrop', {maxWidth: 400, quality: 80});
-			}
-			if (rep.ImageTags?.Primary) {
-				return getImageUrl(repServerUrl, rep.Id, 'Primary', {maxHeight: 300, quality: 80});
-			}
-		}
+		if (rowArtwork) return rowArtwork;
 
-		if (imageType === 'backdrop') {
-			if (item.BackdropImageTags?.length > 0) {
-				return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
-			}
-			if (item.ParentBackdropItemId) {
-				return getImageUrl(itemServerUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 400, quality: 80});
-			}
-			if (item.ImageTags?.Thumb) {
-				return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
-			}
-		} else if (imageType === 'thumb') {
-			if (item.ImageTags?.Thumb) {
-				return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
-			}
-			if (item.ParentThumbItemId) {
-				return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
-			}
-			if (item.BackdropImageTags?.length > 0) {
-				return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
-			}
-		} else if (imageType === 'logo') {
-			if (item.ImageTags?.Logo) {
-				return getImageUrl(itemServerUrl, item.Id, 'Logo', {maxWidth: 400, quality: 80});
-			}
-			if (item.ParentLogoItemId) {
-				return getImageUrl(itemServerUrl, item.ParentLogoItemId, 'Logo', {maxWidth: 400, quality: 80});
-			}
+		if (item.Type === 'Genre' && item._representative && item._representative.ImageTags?.Primary) {
+			return getImageUrl(itemServerUrl, item._representative.Id, 'Primary', {maxHeight: 300, quality: 80});
 		}
 
 		if (isLandscape) {
 			if (item.Type === 'Episode') {
-				const seriesId = item.SeriesId || item.SeriesPrimaryImageItemId || item.ParentPrimaryImageItemId;
-				if (settings.useSeriesThumbnails) {
-					if (item.ParentThumbItemId) {
-						return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
-					}
-					if (seriesId) {
-						return getImageUrl(itemServerUrl, seriesId, 'Thumb', {maxWidth: 400, quality: 80});
-					}
+				// A parent thumb id only arrives when the series really has one, so it is
+				// the series image an episode can ask for without guessing.
+				if (settings.useSeriesThumbnails && item.ParentThumbItemId) {
+					return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
 				}
 				if (item.ImageTags?.Thumb) {
 					return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
@@ -123,8 +124,8 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 				if (item.ImageTags?.Primary) {
 					return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxWidth: 400, quality: 80});
 				}
-				if (seriesId) {
-					return getImageUrl(itemServerUrl, seriesId, 'Primary', {maxHeight: 300, quality: 80});
+				if (item.SeriesId && item.SeriesPrimaryImageTag) {
+					return getImageUrl(itemServerUrl, item.SeriesId, 'Primary', {maxHeight: 300, quality: 80});
 				}
 			} else {
 				if (item.ImageTags?.Thumb) {
@@ -145,29 +146,6 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 			}
 		}
 
-		if (imageType === 'backdrop') {
-			if (item.BackdropImageTags?.length > 0) {
-				return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 400, quality: 80});
-			}
-			if (item.ParentBackdropItemId) {
-				return getImageUrl(itemServerUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 400, quality: 80});
-			}
-		} else if (imageType === 'thumb') {
-			if (item.ImageTags?.Thumb) {
-				return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 400, quality: 80});
-			}
-			if (item.ParentThumbItemId) {
-				return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 400, quality: 80});
-			}
-		} else if (imageType === 'logo') {
-			if (item.ImageTags?.Logo) {
-				return getImageUrl(itemServerUrl, item.Id, 'Logo', {maxWidth: 400, quality: 80});
-			}
-			if (item.ParentLogoItemId) {
-				return getImageUrl(itemServerUrl, item.ParentLogoItemId, 'Logo', {maxWidth: 400, quality: 80});
-			}
-		}
-
 		if (item.ImageTags?.Primary) {
 			return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 300, quality: 80});
 		}
@@ -180,12 +158,10 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 			return toAbsoluteImageUrl(externalPoster, itemServerUrl);
 		}
 
-		if (item.Id) {
-			return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 300, quality: 80});
-		}
-
+		// The card shows its lettered placeholder rather than guessing at a url the
+		// item already said it has nothing behind.
 		return null;
-	}, [isLandscape, item, itemServerUrl, imageType, settings.useSeriesThumbnails]);
+	}, [isLandscape, item, itemServerUrl, rowArtwork, settings.useSeriesThumbnails]);
 
 	const handleClick = useCallback(() => {
 		onSelect?.(item);
@@ -237,6 +213,11 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 	const cardHeight = Math.round(baseH * sizeMultiplier);
 	const sizeStyle = sizeMultiplier !== 1 ? {width: cardWidth + 'px'} : undefined;
 	const imgSizeStyle = sizeMultiplier !== 1 ? {height: cardHeight + 'px'} : undefined;
+	// A logo has to sit inside the card whole. Everything else takes the cover the
+	// stylesheet already applies, so it stays out of the inline style.
+	const imgStyle = imageType === 'logo'
+		? {...imgSizeStyle, objectFit: 'contain'}
+		: imgSizeStyle;
 
 	return (
 		<SpottableDiv className={cardClass} data-media-card onClick={handleClick} onFocus={handleFocus} style={sizeStyle} spotlightId={spotlightId} onSpotlightLeft={onSpotlightLeft} onSpotlightRight={onSpotlightRight}>
@@ -250,10 +231,7 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', onSelect, onFocusIte
 							loading={eagerLoad ? 'eager' : 'lazy'}
 							width={cardWidth}
 							height={cardHeight}
-							style={{
-								...(imgSizeStyle || {}),
-								objectFit: imageType === 'logo' ? 'contain' : 'cover'
-							}}
+							style={imgStyle}
 						/>
 						{(item?.Type === 'Genre' || item?.Type === 'MusicGenre') && (
 							<>

--- a/packages/app/src/components/MediaCard/ModernMediaCard.js
+++ b/packages/app/src/components/MediaCard/ModernMediaCard.js
@@ -30,6 +30,7 @@ const formatRuntime = (ticks) => {
 	const minutes = totalMinutes % 60;
 	if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`;
 	if (hours > 0) return `${hours}h`;
+	return `${minutes}m`;
 };
 
 const getGenreNames = (item) => {
@@ -113,7 +114,9 @@ const ModernMediaCard = ({
 		}
 
 		if (item.Type === 'Episode') {
-			const seriesId = item.SeriesId || item.SeriesPrimaryImageItemId || item.ParentPrimaryImageItemId;
+			// Both of these only appear once the series really holds the image, so an
+			// episode can follow them without guessing at what its series has.
+			const seriesId = item.SeriesPrimaryImageTag ? item.SeriesId : item.ParentPrimaryImageItemId;
 			const seriesPoster = seriesId
 				? getImageUrl(itemServerUrl, seriesId, 'Primary', {maxHeight: 360, quality: 80})
 				: item.ImageTags?.Primary
@@ -121,9 +124,7 @@ const ModernMediaCard = ({
 					: null;
 			const seriesThumb = item.ParentThumbItemId
 				? getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 600, quality: 80})
-				: seriesId
-					? getImageUrl(itemServerUrl, seriesId, 'Thumb', {maxWidth: 600, quality: 80})
-					: null;
+				: null;
 			const episodeThumb = item.ImageTags?.Primary
 				? getImageUrl(itemServerUrl, item.Id, 'Primary', {maxWidth: 600, quality: 80})
 				: item.ImageTags?.Thumb
@@ -171,13 +172,9 @@ const ModernMediaCard = ({
 				if (item._externalBackdropUrl) {
 					return toAbsoluteImageUrl(item._externalBackdropUrl, itemServerUrl);
 				}
-				if (item.Id) {
-					return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 600, quality: 80});
-				}
-			} else {
-				if (item.Id) {
-					return getImageUrl(itemServerUrl, item.Id, 'Primary', {tag: item.ImageTags?.Primary, maxHeight: 360, quality: 80});
-				}
+			}
+			if (item.ImageTags?.Primary) {
+				return getImageUrl(itemServerUrl, item.Id, 'Primary', {tag: item.ImageTags.Primary, maxHeight: 360, quality: 80});
 			}
 		}
 
@@ -210,13 +207,13 @@ const ModernMediaCard = ({
 			if (item.ParentThumbItemId) {
 				return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 600, quality: 80});
 			}
-			if (item.Id) {
+			if (item.BackdropImageTags?.length > 0) {
 				return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 600, quality: 80});
 			}
-		} else {
-			if (item.Id) {
-				return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 360, quality: 80});
-			}
+		}
+
+		if (item.ImageTags?.Primary) {
+			return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 360, quality: 80});
 		}
 
 		if (externalPoster) {

--- a/packages/app/src/components/MediaCard/ModernMediaCard.js
+++ b/packages/app/src/components/MediaCard/ModernMediaCard.js
@@ -30,7 +30,6 @@ const formatRuntime = (ticks) => {
 	const minutes = totalMinutes % 60;
 	if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`;
 	if (hours > 0) return `${hours}h`;
-	return `${minutes}m`;
 };
 
 const getGenreNames = (item) => {
@@ -96,23 +95,50 @@ const ModernMediaCard = ({
 	const imageUrl = useMemo(() => {
 		if (!item) return null;
 
+		const providerIds = item.ProviderIds || {};
+		const externalPoster = item._externalPosterUrl ||
+			providerIds.SeerrPoster ||
+			providerIds.SonarrPoster ||
+			providerIds.RadarrPoster ||
+			providerIds.LidarrPoster ||
+			providerIds.ReadarrPoster;
+
+		if (item._external || externalPoster) {
+			if (isFocused && item._externalBackdropUrl) {
+				return toAbsoluteImageUrl(item._externalBackdropUrl, itemServerUrl);
+			}
+			if (externalPoster) {
+				return toAbsoluteImageUrl(externalPoster, itemServerUrl);
+			}
+		}
+
 		if (item.Type === 'Episode') {
-			const seriesPoster = item.SeriesId && item.SeriesPrimaryImageTag
-				? getImageUrl(itemServerUrl, item.SeriesId, 'Primary', {maxHeight: 360, quality: 80})
-				: null;
+			const seriesId = item.SeriesId || item.SeriesPrimaryImageItemId || item.ParentPrimaryImageItemId;
+			const seriesPoster = seriesId
+				? getImageUrl(itemServerUrl, seriesId, 'Primary', {maxHeight: 360, quality: 80})
+				: item.ImageTags?.Primary
+					? getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 360, quality: 80})
+					: null;
+			const seriesThumb = item.ParentThumbItemId
+				? getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 600, quality: 80})
+				: seriesId
+					? getImageUrl(itemServerUrl, seriesId, 'Thumb', {maxWidth: 600, quality: 80})
+					: null;
 			const episodeThumb = item.ImageTags?.Primary
 				? getImageUrl(itemServerUrl, item.Id, 'Primary', {maxWidth: 600, quality: 80})
-				: item.ParentThumbItemId
-					? getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 600, quality: 80})
-					: item.ParentBackdropItemId
-						? getImageUrl(itemServerUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 600, quality: 80})
-						: null;
-			// the series poster keeps the row a uniform portrait grid, the
-			// landscape episode thumbnail shows once the card expands
-			const episodeImage = isFocused
-				? (episodeThumb || seriesPoster)
-				: (settings.useSeriesThumbnails && seriesPoster) ? seriesPoster : (episodeThumb || seriesPoster);
-			if (episodeImage) return episodeImage;
+				: item.ImageTags?.Thumb
+					? getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 600, quality: 80})
+					: item.BackdropImageTags?.length > 0
+						? getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 600, quality: 80})
+						: item.ParentBackdropItemId
+							? getImageUrl(itemServerUrl, item.ParentBackdropItemId, 'Backdrop', {maxWidth: 600, quality: 80})
+							: null;
+
+			if (isFocused) {
+				return (settings.useSeriesThumbnails ? (seriesThumb || episodeThumb) : (episodeThumb || seriesThumb)) || seriesPoster;
+			} else {
+				return seriesPoster || episodeThumb || seriesThumb;
+			}
 		}
 
 		if (item.Type === 'Genre' && item._representative) {
@@ -132,28 +158,26 @@ const ModernMediaCard = ({
 		}
 
 		if (item.Type === 'Movie' || item.Type === 'Series' || item.Type === 'BoxSet') {
-			const imageType = settings.homeRowsImageType || 'poster';
 			if (isFocused) {
 				if (item.ImageTags?.Thumb) {
-					return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 600, quality: 80});
+					return getImageUrl(itemServerUrl, item.Id, 'Thumb', {tag: item.ImageTags.Thumb, maxWidth: 600, quality: 80});
+				}
+				if (item.ParentThumbItemId) {
+					return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 600, quality: 80});
 				}
 				if (item.BackdropImageTags?.length > 0) {
-					return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 600, quality: 80});
+					return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {tag: item.BackdropImageTags[0], maxWidth: 600, quality: 80});
 				}
 				if (item._externalBackdropUrl) {
 					return toAbsoluteImageUrl(item._externalBackdropUrl, itemServerUrl);
 				}
-			}
-
-			if (imageType === 'thumb' && item.ImageTags?.Thumb) {
-				return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 600, quality: 80});
-			}
-			if (imageType === 'backdrop' && item.BackdropImageTags?.length > 0) {
-				return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 600, quality: 80});
-			}
-
-			if (item.ImageTags?.Primary) {
-				return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 360, quality: 80});
+				if (item.Id) {
+					return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 600, quality: 80});
+				}
+			} else {
+				if (item.Id) {
+					return getImageUrl(itemServerUrl, item.Id, 'Primary', {tag: item.ImageTags?.Primary, maxHeight: 360, quality: 80});
+				}
 			}
 		}
 
@@ -179,29 +203,28 @@ const ModernMediaCard = ({
 			return getImageUrl(itemServerUrl, item.AlbumId, 'Primary', {maxHeight: 360, quality: 80});
 		}
 
-		if (item.ImageTags?.Primary) {
-			return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 360, quality: 80});
+		if (isFocused) {
+			if (item.ImageTags?.Thumb) {
+				return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 600, quality: 80});
+			}
+			if (item.ParentThumbItemId) {
+				return getImageUrl(itemServerUrl, item.ParentThumbItemId, 'Thumb', {maxWidth: 600, quality: 80});
+			}
+			if (item.Id) {
+				return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 600, quality: 80});
+			}
+		} else {
+			if (item.Id) {
+				return getImageUrl(itemServerUrl, item.Id, 'Primary', {maxHeight: 360, quality: 80});
+			}
 		}
 
-		if (item.ImageTags?.Thumb) {
-			return getImageUrl(itemServerUrl, item.Id, 'Thumb', {maxWidth: 600, quality: 80});
-		}
-
-		if (item.BackdropImageTags?.length > 0) {
-			return getImageUrl(itemServerUrl, item.Id, 'Backdrop', {maxWidth: 600, quality: 80});
-		}
-		const providerIds = item.ProviderIds || {};
-		const externalPoster = item._externalPosterUrl ||
-			providerIds.SeerrPoster ||
-			providerIds.SonarrPoster ||
-			providerIds.RadarrPoster ||
-			providerIds.LidarrPoster ||
-			providerIds.ReadarrPoster;
 		if (externalPoster) {
 			return toAbsoluteImageUrl(externalPoster, itemServerUrl);
 		}
+
 		return null;
-	}, [item, itemServerUrl, isFocused, settings.useSeriesThumbnails, settings.homeRowsImageType]);
+	}, [item, itemServerUrl, isFocused, settings.useSeriesThumbnails]);
 
 	const handleClick = useCallback(() => {
 		onSelect?.(item);

--- a/packages/app/src/components/MediaRow/MediaRow.js
+++ b/packages/app/src/components/MediaRow/MediaRow.js
@@ -22,6 +22,7 @@ const MediaRow = ({
 	items,
 	serverUrl,
 	cardType = 'portrait',
+	rowImageType = 'poster',
 	onSelectItem,
 	onFocus,
 	onFocusItem,
@@ -158,6 +159,7 @@ const MediaRow = ({
 									item={item}
 									serverUrl={serverUrl}
 									cardType={cardType}
+									rowImageType={rowImageType}
 									onSelect={handleSelect}
 									onFocusItem={onFocusItem}
 									showServerBadge={showServerBadge}
@@ -179,6 +181,7 @@ const areRowPropsEqual = (prev, next) => {
 	if (prev.rowId !== next.rowId) return false;
 	if (prev.title !== next.title) return false;
 	if (prev.cardType !== next.cardType) return false;
+	if (prev.rowImageType !== next.rowImageType) return false;
 	if (prev.serverUrl !== next.serverUrl) return false;
 	if (prev.rowIndex !== next.rowIndex) return false;
 	if (prev.showServerBadge !== next.showServerBadge) return false;

--- a/packages/app/src/views/Browse/Browse.js
+++ b/packages/app/src/views/Browse/Browse.js
@@ -2176,6 +2176,7 @@ const Browse = ({
 								items={row.items}
 								serverUrl={serverUrl}
 								cardType={row.type}
+								rowImageType={settings.homeRowsImageType}
 								onSelectItem={selectHandler}
 								onFocus={handleRowFocus}
 								onFocusItem={handleFocusItem}


### PR DESCRIPTION
# Pull Request

## Summary
Fix home row image resolution logic for both Classic and Modern layouts, ensuring unfocused/focused cards flip correctly between 2:3 vertical posters and 16:9 landscape thumbnails/backdrops, and fixing aspect ratios for per-row image selection.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #324 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **ModernMediaCard.js**: Ensure Movie, Series, and Episode unfocused cards render 2:3 vertical Primary posters, while focused cards expand to 16:9 landscape and render 16:9 thumbnails or backdrops.
- **MediaCard.js**: Fix per-row image type selection for Classic rows so that `Poster` uses 2:3 portrait cards, while `Thumb`, `Backdrop`, and `Logo` dynamically switch card container dimensions to 16:9 landscape (`384x216px`).
- **MediaCard.js**: Ensure `Backdrop` image selection prioritizes clean backdrop artwork (`BackdropImageTags`) over thumbnails (`Thumb`), and apply `objectFit: 'contain'` for `Logo` image selection.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin Smart-TV and test home rows in Modern view (unfocused vs focused states for Movies and Episodes).
2. Switch to Classic view and test *Per Row Image Type Selection* under Settings for Poster, Backdrop, Thumb, and Logo options.
3. Verify that external rows (Radarr, Sonarr, Letterboxd) render artwork without falling back to blank cards.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Classic Rows (all image types correctly render):

<img width="2544" height="1362" alt="2026-08-01_12-17-55_brave" src="https://github.com/user-attachments/assets/82e0e06e-d730-478f-a1e3-d987a274441d" />
<img width="2544" height="1362" alt="2026-08-01_12-18-04_brave" src="https://github.com/user-attachments/assets/dbde8bfa-005c-446f-a1a4-1cfa8e420948" />
<img width="2544" height="1362" alt="2026-08-01_12-18-10_brave" src="https://github.com/user-attachments/assets/23e1eaa9-9717-4259-9b3f-29202c58961f" />
<img width="2544" height="1362" alt="2026-08-01_12-18-32_brave" src="https://github.com/user-attachments/assets/7364af29-e315-4de8-9bed-cf772b55e869" />

### Modern Rows 

<img width="2519" height="1278" alt="2026-08-01_11-56-36_msedge" src="https://github.com/user-attachments/assets/7b4764fe-92ef-4fdf-b3e5-0e9182652d0d" />
<img width="2519" height="1278" alt="2026-08-01_11-56-46_msedge" src="https://github.com/user-attachments/assets/909c0702-a329-4f8e-b548-19eb990fe5a9" />
<img width="2518" height="1206" alt="2026-08-01_11-59-00_brave" src="https://github.com/user-attachments/assets/f3c23536-5eb7-4793-9f5b-155317031759" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
