### PR TITLE
[Tizen] Fix forced transcode for AAC 5.1 on Tizen 5.5 - #322

### DIFF
--- a/packages/platform-tizen/src/deviceProfile.js
+++ b/packages/platform-tizen/src/deviceProfile.js
@@ -574,8 +574,11 @@ export const getJellyfinDeviceProfile = async () => {
 	// fMP4 HLS is only for AV1 passthrough since TS cant carry AV1. HEVC/H.264
 	// use TS because copying HEVC (especially Dolby Vision) into fMP4 HLS fails
 	// on several Tizen firmwares, so they must not match the fMP4 profile
-	const tsAudio = caps.eac3 ? 'eac3,ac3,aac' : (caps.ac3 ? 'ac3,aac' : 'aac');
-	const transcodingProfiles = [];
+	const isOldTizen = caps.tizenVersion < 6;
+	const tsAudio = isOldTizen
+	? (caps.eac3 ? 'eac3,ac3' : (caps.ac3 ? 'ac3' : 'aac'))
+	: (caps.eac3 ? 'eac3,ac3,aac' : (caps.ac3 ? 'ac3,aac' : 'aac'));
+  	const transcodingProfiles = [];
 
 	// hevc inside HLS TS only demuxes reliably from Tizen 6 up. Short segments
 	// and non keyframe breaks stall AVPlay on segment boundaries, so use longer
@@ -727,13 +730,13 @@ export const getJellyfinDeviceProfile = async () => {
 	];
 
 	// multichannel AAC in a TS stream crashes the decoder on these sets
-	if (caps.tizenVersion < 6) {
-		codecProfiles.push({
-			Type: 'VideoAudio',
-			Codec: 'aac',
-			Conditions: [{ Condition: 'LessThanEqual', Property: 'AudioChannels', Value: '2', IsRequired: true }]
-		});
-	}
+	// if (caps.tizenVersion < 6) {
+	// 	codecProfiles.push({
+	// 		Type: 'VideoAudio',
+	// 		Codec: 'aac',
+	// 		Conditions: [{ Condition: 'LessThanEqual', Property: 'AudioChannels', Value: '2', IsRequired: true }]
+	// 	});
+	// }
 
 	// Force any kind of DTS to be transcoded to E-AC3 
 	codecProfiles.push({

--- a/packages/platform-tizen/src/deviceProfile.js
+++ b/packages/platform-tizen/src/deviceProfile.js
@@ -576,9 +576,9 @@ export const getJellyfinDeviceProfile = async () => {
 	// on several Tizen firmwares, so they must not match the fMP4 profile
 	const isOldTizen = caps.tizenVersion < 6;
 	const tsAudio = isOldTizen
-	? (caps.eac3 ? 'eac3,ac3' : (caps.ac3 ? 'ac3' : 'aac'))
-	: (caps.eac3 ? 'eac3,ac3,aac' : (caps.ac3 ? 'ac3,aac' : 'aac'));
-  	const transcodingProfiles = [];
+		? (caps.eac3 ? 'eac3,ac3' : (caps.ac3 ? 'ac3' : 'mp3'))
+		: (caps.eac3 ? 'eac3,ac3,aac' : (caps.ac3 ? 'ac3,aac' : 'aac'));
+	const transcodingProfiles = [];
 
 	// hevc inside HLS TS only demuxes reliably from Tizen 6 up. Short segments
 	// and non keyframe breaks stall AVPlay on segment boundaries, so use longer

--- a/packages/platform-tizen/src/deviceProfile.js
+++ b/packages/platform-tizen/src/deviceProfile.js
@@ -730,13 +730,16 @@ export const getJellyfinDeviceProfile = async () => {
 	];
 
 	// multichannel AAC in a TS stream crashes the decoder on these sets
-	// if (caps.tizenVersion < 6) {
-	// 	codecProfiles.push({
-	// 		Type: 'VideoAudio',
-	// 		Codec: 'aac',
-	// 		Conditions: [{ Condition: 'LessThanEqual', Property: 'AudioChannels', Value: '2', IsRequired: true }]
-	// 	});
-	// }
+	// 5.1 AAC in TS crashes these sets, so cap it there. Without the container it also
+	// caught MP4 and MKV, which is what forced the whole file to transcode.
+	if (isOldTizen) {
+		codecProfiles.push({
+			Type: 'VideoAudio',
+			Container: 'ts,mpegts',
+			Codec: 'aac',
+			Conditions: [{ Condition: 'LessThanEqual', Property: 'AudioChannels', Value: '2', IsRequired: true }]
+		});
+	}
 
 	// Force any kind of DTS to be transcoded to E-AC3 
 	codecProfiles.push({


### PR DESCRIPTION
…- fixes #322

# Pull Request

## Summary
Regression from f492738. The VideoAudio aac <=2ch profile was meant to avoid TS AAC crash on <6, but it blocks MP4/MKV AAC 5.1 DirectPlay, forcing HEVC→H264 transcode (TS H264 AC3, reason audio channels not supported). Fix by removing the global VideoAudio restriction and excluding AAC from the TS transcoding target for old Tizen. Tested on Tizen 5.5 HEVC Main10@L120 + AAC 5.1 → now DirectPlay.

## Related Issues

- Fixes #322


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- 
- 
- 

## Platform
- [x] Tizen (Samsung)
- [ ] webOS (LG)
- [ ] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [ ] Code builds successfully
- [ ] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
