### PR TITLE
fix missing focus on shuffle picker dialogs

### DIFF
--- a/packages/app/src/components/ShuffleOverlay/ShuffleOverlay.js
+++ b/packages/app/src/components/ShuffleOverlay/ShuffleOverlay.js
@@ -63,13 +63,13 @@ const getFocusList = (items) => {
 	];
 };
 
-const PickerDialog = ({open, title, items, loading, emptyLabel, onClose, onPick}) => {
+const PickerDialog = ({open, title, items, loading, emptyLabel, onClose, onPick, pickerSpotlightId}) => {
 	const overlayClassName = `${css.pickerOverlay} ${open ? css.pickerOverlayOpen : css.pickerOverlayHidden}`;
 	const dialogClassName = `${css.pickerDialog} ${open ? css.pickerDialogOpen : css.pickerDialogClosed}`;
 
 	return (
 		<div aria-hidden={!open} className={overlayClassName}>
-			<PickerContainer className={dialogClassName} spotlightDisabled={!open} spotlightId="shuffle-picker-dialog">
+			<PickerContainer className={dialogClassName} spotlightDisabled={!open} spotlightId={pickerSpotlightId}>
 				<h3 className={css.pickerTitle}>{title}</h3>
 				{loading ? (
 					<div className={css.pickerLoading}>{$L('Loading...')}</div>
@@ -250,6 +250,7 @@ const ShuffleOverlay = ({
 		} finally {
 			setPickerLoading(false);
 		}
+		Spotlight.focus('shuffle-library-picker-dialog');
 	}, [api, contentType, unifiedMode]);
 
 	const openGenrePicker = useCallback(async () => {
@@ -262,6 +263,7 @@ const ShuffleOverlay = ({
 		} finally {
 			setPickerLoading(false);
 		}
+		Spotlight.focus('shuffle-genre-picker-dialog');
 	}, [api, contentType, unifiedMode]);
 
 	const handlePickLibrary = useCallback((library) => {
@@ -415,6 +417,7 @@ const ShuffleOverlay = ({
 				emptyLabel={$L('No libraries found')}
 				onClose={() => setPickerMode('')}
 				onPick={handlePickLibrary}
+				pickerSpotlightId={"shuffle-library-picker-dialog"}
 			/>
 			<PickerDialog
 				open={pickerMode === 'genre'}
@@ -424,6 +427,7 @@ const ShuffleOverlay = ({
 				emptyLabel={$L('No genres found')}
 				onClose={() => setPickerMode('')}
 				onPick={handlePickGenre}
+				pickerSpotlightId={"shuffle-genre-picker-dialog"}
 			/>
 		</div>
 	);

--- a/packages/app/src/components/ShuffleOverlay/ShuffleOverlay.js
+++ b/packages/app/src/components/ShuffleOverlay/ShuffleOverlay.js
@@ -28,6 +28,12 @@ const PickerContainer = SpotlightContainerDecorator({
 
 const SpottableButton = Spottable('button');
 
+// Both pickers stay mounted, so each needs its own id or Spotlight only keeps one of them.
+const PICKER_SPOTLIGHT_IDS = {
+	library: 'shuffle-library-picker-dialog',
+	genre: 'shuffle-genre-picker-dialog'
+};
+
 const buildItemImageUrl = (item, fallbackServerUrl, fallbackAccessToken) => {
 	const serverUrl = item?._serverUrl || fallbackServerUrl;
 	const accessToken = item?._serverAccessToken || fallbackAccessToken;
@@ -63,13 +69,13 @@ const getFocusList = (items) => {
 	];
 };
 
-const PickerDialog = ({open, title, items, loading, emptyLabel, onClose, onPick, pickerSpotlightId}) => {
+const PickerDialog = ({open, title, items, loading, emptyLabel, onClose, onPick, spotlightId}) => {
 	const overlayClassName = `${css.pickerOverlay} ${open ? css.pickerOverlayOpen : css.pickerOverlayHidden}`;
 	const dialogClassName = `${css.pickerDialog} ${open ? css.pickerDialogOpen : css.pickerDialogClosed}`;
 
 	return (
 		<div aria-hidden={!open} className={overlayClassName}>
-			<PickerContainer className={dialogClassName} spotlightDisabled={!open} spotlightId={pickerSpotlightId}>
+			<PickerContainer className={dialogClassName} spotlightDisabled={!open} spotlightId={spotlightId}>
 				<h3 className={css.pickerTitle}>{title}</h3>
 				{loading ? (
 					<div className={css.pickerLoading}>{$L('Loading...')}</div>
@@ -85,7 +91,7 @@ const PickerDialog = ({open, title, items, loading, emptyLabel, onClose, onPick,
 									key={id}
 									className={`${css.pickerItem} ${index === 0 ? 'spottable-default' : ''}`}
 									onClick={() => onPick(item)}
-									spotlightId={`shuffle-picker-item-${index}`}
+									spotlightId={`${spotlightId}-item-${index}`}
 								>
 									{label}
 								</SpottableButton>
@@ -96,7 +102,7 @@ const PickerDialog = ({open, title, items, loading, emptyLabel, onClose, onPick,
 				<SpottableButton
 					className={css.pickerCancel}
 					onClick={onClose}
-					spotlightId="shuffle-picker-cancel"
+					spotlightId={`${spotlightId}-cancel`}
 				>
 					{$L('Cancel')}
 				</SpottableButton>
@@ -193,6 +199,18 @@ const ShuffleOverlay = ({
 		return () => clearTimeout(timer);
 	}, [open, items, pickerMode]);
 
+	// Waiting for the list to be on screen is what puts focus on the first entry. Doing it
+	// as the picker opens only ever finds the Cancel button, since that is all there is
+	// while the fetch runs. Loading finishing either way is what starts this, so a failed
+	// fetch still leaves the dialog somewhere to be.
+	useEffect(() => {
+		if (!open || !pickerMode || pickerLoading) return;
+		const id = PICKER_SPOTLIGHT_IDS[pickerMode];
+		if (!id) return;
+		const timer = setTimeout(() => Spotlight.focus(id), 50);
+		return () => clearTimeout(timer);
+	}, [open, pickerMode, pickerLoading]);
+
 	useEffect(() => {
 		if (!open) return;
 		const handleKey = (e) => {
@@ -250,7 +268,6 @@ const ShuffleOverlay = ({
 		} finally {
 			setPickerLoading(false);
 		}
-		Spotlight.focus('shuffle-library-picker-dialog');
 	}, [api, contentType, unifiedMode]);
 
 	const openGenrePicker = useCallback(async () => {
@@ -263,7 +280,6 @@ const ShuffleOverlay = ({
 		} finally {
 			setPickerLoading(false);
 		}
-		Spotlight.focus('shuffle-genre-picker-dialog');
 	}, [api, contentType, unifiedMode]);
 
 	const handlePickLibrary = useCallback((library) => {
@@ -417,7 +433,7 @@ const ShuffleOverlay = ({
 				emptyLabel={$L('No libraries found')}
 				onClose={() => setPickerMode('')}
 				onPick={handlePickLibrary}
-				pickerSpotlightId={"shuffle-library-picker-dialog"}
+				spotlightId={PICKER_SPOTLIGHT_IDS.library}
 			/>
 			<PickerDialog
 				open={pickerMode === 'genre'}
@@ -427,7 +443,7 @@ const ShuffleOverlay = ({
 				emptyLabel={$L('No genres found')}
 				onClose={() => setPickerMode('')}
 				onPick={handlePickGenre}
-				pickerSpotlightId={"shuffle-genre-picker-dialog"}
+				spotlightId={PICKER_SPOTLIGHT_IDS.genre}
 			/>
 		</div>
 	);


### PR DESCRIPTION
# Pull Request

## Summary
Focus was never set to the picker dialogs inside the shuffle dialog, so users could not navigate/select anything. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #332 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- set spotlight focus on shuffle picker dialog when opening it
- created dynamic unique spotlightId for library/genre picker dialogs so focus would not be hoarded by only one
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Use keyboard to navigate to the shuffle dialog
2. Down arrow then enter to go to library/genre buttons
3. When the pickers open, you will now be able to use the keyboard to navigate the list and select an item

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
