### PR TITLE
add random sort option to library page

### DIFF
--- a/packages/app/src/views/Library/Library.js
+++ b/packages/app/src/views/Library/Library.js
@@ -34,7 +34,8 @@ const SORT_OPTIONS = [
 	{key: 'CommunityRating', field: 'CommunityRating', order: 'Descending', label: $L('Community Rating')},
 	{key: 'CriticRating', field: 'CriticRating', order: 'Descending', label: $L('Critic Rating')},
 	{key: 'DatePlayed', field: 'DatePlayed', order: 'Descending', label: $L('Last Played')},
-	{key: 'Runtime', field: 'Runtime', order: 'Ascending', label: $L('Runtime')}
+	{key: 'Runtime', field: 'Runtime', order: 'Ascending', label: $L('Runtime')},
+	{key: 'Random', field: 'Random', order: 'Ascending', label: $L('Random')}
 ];
 
 const MUSIC_SORT_OPTIONS = [


### PR DESCRIPTION
# Pull Request

## Summary
There was no random sort, I added it, it was actually surprisingly easy since jellyfin handles the sorting, moonfin just needs to pass the sortBy key

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #333 
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add "Random" to SORT_OPTIONS 
- that was literally it, I just added it to the list of options and it worked
- 

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Go to a library
2. Change sort to "random"
3. Items now have a random order

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
