### PR TITLE
fix-ui - Spoilermode Extension, the Smart-TV Port

### DIFF
--- a/packages/app/src/views/Details/ModernDetailContent.js
+++ b/packages/app/src/views/Details/ModernDetailContent.js
@@ -371,7 +371,7 @@ const ModernDetailContent = (props) => {
 						<div className={css.episodeBody}>
 							<span className={css.episodeName}>{label}</span>
 							{epRuntime && <span className={css.episodeMeta}>{epRuntime}</span>}
-							{ep.Overview && <p className={css.episodeOverview}>{ep.Overview}</p>}
+							{!hidesMediaDescription(ep, settings) && ep.Overview && <p className={css.episodeOverview}>{ep.Overview}</p>}
 						</div>
 					</SpottableDiv>
 				);
@@ -711,7 +711,7 @@ const ModernDetailContent = (props) => {
 					<div className={css.upNextLabel}>{`${$L('Next Up')} - ${code}${ep.Name}`}</div>
 					<div className={css.upNextBody}>
 						<div className={css.upNextText}>
-							{ep.Overview && <span className={css.upNextOverview}>{ep.Overview}</span>}
+							{!hidesMediaDescription(ep, settings) && ep.Overview && <span className={css.upNextOverview}>{ep.Overview}</span>}
 							<div className={css.upNextFoot}>
 								{progress > 0 && <div className={css.upNextProgress}><div style={{width: `${Math.min(progress, 100)}%`}} /></div>}
 								{remaining && <span className={css.upNextRemaining}>{$L('{time} remaining').replace('{time}', remaining)}</span>}

--- a/packages/app/src/views/Details/ModernDetailContent.js
+++ b/packages/app/src/views/Details/ModernDetailContent.js
@@ -371,7 +371,7 @@ const ModernDetailContent = (props) => {
 						<div className={css.episodeBody}>
 							<span className={css.episodeName}>{label}</span>
 							{epRuntime && <span className={css.episodeMeta}>{epRuntime}</span>}
-							{!hidesMediaDescription(ep, settings) && ep.Overview && <p className={css.episodeOverview}>{ep.Overview}</p>}
+							{ep.Overview && !hidesMediaDescription(ep, settings) && <p className={css.episodeOverview}>{ep.Overview}</p>}
 						</div>
 					</SpottableDiv>
 				);
@@ -711,7 +711,7 @@ const ModernDetailContent = (props) => {
 					<div className={css.upNextLabel}>{`${$L('Next Up')} - ${code}${ep.Name}`}</div>
 					<div className={css.upNextBody}>
 						<div className={css.upNextText}>
-							{!hidesMediaDescription(ep, settings) && ep.Overview && <span className={css.upNextOverview}>{ep.Overview}</span>}
+							{ep.Overview && !hidesMediaDescription(ep, settings) && <span className={css.upNextOverview}>{ep.Overview}</span>}
 							<div className={css.upNextFoot}>
 								{progress > 0 && <div className={css.upNextProgress}><div style={{width: `${Math.min(progress, 100)}%`}} /></div>}
 								{remaining && <span className={css.upNextRemaining}>{$L('{time} remaining').replace('{time}', remaining)}</span>}

--- a/packages/app/src/views/Details/SeasonScreen.js
+++ b/packages/app/src/views/Details/SeasonScreen.js
@@ -136,7 +136,7 @@ const SeasonScreen = ({
 								</span>
 							</div>
 							<span className={css.seasonEpTitle}>{ep.Name}</span>
-							{!hidesMediaDescription(ep, settings) && ep.Overview && <p className={css.seasonEpOverview}>{ep.Overview}</p>}
+							{ep.Overview && !hidesMediaDescription(ep, settings) && <p className={css.seasonEpOverview}>{ep.Overview}</p>}
 						</div>
 					</SpottableDiv>
 				);

--- a/packages/app/src/views/Details/SeasonScreen.js
+++ b/packages/app/src/views/Details/SeasonScreen.js
@@ -2,6 +2,7 @@ import $L from '@enact/i18n/$L';
 
 import RatingsRow from '../../components/RatingsRow';
 import {formatDuration, getImageUrl} from '../../utils/helpers';
+import {hidesMediaDescription} from './detailsMedia';
 import {isMdblistEnabled} from '../../services/mdblistApi';
 import {DETAIL_ICON_PATHS} from './detailIcons';
 import {SpottableDiv, HorizontalContainer} from './detailsSpottables';
@@ -135,7 +136,7 @@ const SeasonScreen = ({
 								</span>
 							</div>
 							<span className={css.seasonEpTitle}>{ep.Name}</span>
-							{ep.Overview && <p className={css.seasonEpOverview}>{ep.Overview}</p>}
+							{!hidesMediaDescription(ep, settings) && ep.Overview && <p className={css.seasonEpOverview}>{ep.Overview}</p>}
 						</div>
 					</SpottableDiv>
 				);

--- a/packages/app/src/views/Details/detailsMedia.js
+++ b/packages/app/src/views/Details/detailsMedia.js
@@ -23,7 +23,10 @@ export const IDENTIFIABLE_TYPES = ['Movie', 'Series', 'Season', 'Episode', 'BoxS
 // description either way.
 export const hidesMediaDescription = (item, settings) =>
 	settings?.hideDetailsMediaDescription === true &&
-	(item?.Type === 'Movie' || item?.Type === 'Episode');
+	item?.Type !== 'Series' &&
+	item?.Type !== 'Season' &&
+	item?.Type !== 'BoxSet' &&
+	item?.Type !== 'Person';
 
 // The parent series artwork, for standing in where an episode still or a chapter
 // frame would give something away. Null when the series offers no artwork, which

--- a/packages/app/src/views/Details/detailsMedia.js
+++ b/packages/app/src/views/Details/detailsMedia.js
@@ -23,10 +23,7 @@ export const IDENTIFIABLE_TYPES = ['Movie', 'Series', 'Season', 'Episode', 'BoxS
 // description either way.
 export const hidesMediaDescription = (item, settings) =>
 	settings?.hideDetailsMediaDescription === true &&
-	item?.Type !== 'Series' &&
-	item?.Type !== 'Season' &&
-	item?.Type !== 'BoxSet' &&
-	item?.Type !== 'Person';
+	(item?.Type === 'Movie' || item?.Type === 'Episode');
 
 // The parent series artwork, for standing in where an episode still or a chapter
 // frame would give something away. Null when the series offers no artwork, which

--- a/packages/app/src/views/Details/detailsMedia.test.js
+++ b/packages/app/src/views/Details/detailsMedia.test.js
@@ -7,25 +7,36 @@ import {splitCastAndCrew, hidesMediaDescription} from './detailsMedia';
 const person = (Id, Name, Type, Role) => ({Id, Name, Type, Role});
 
 describe('hidesMediaDescription', () => {
-	test('returns true for Movie or Episode when hideDetailsMediaDescription is enabled', () => {
-		const settings = {hideDetailsMediaDescription: true};
-		expect(hidesMediaDescription({Type: 'Movie'}, settings)).toBe(true);
-		expect(hidesMediaDescription({Type: 'Episode'}, settings)).toBe(true);
-		expect(hidesMediaDescription({IndexNumber: 1}, settings)).toBe(true);
+	const on = {hideDetailsMediaDescription: true};
+
+	test('a film and an episode give the story away, so they are held back', () => {
+		expect(hidesMediaDescription({Type: 'Movie'}, on)).toBe(true);
+		expect(hidesMediaDescription({Type: 'Episode'}, on)).toBe(true);
 	});
 
-	test('returns false for Series, Season, BoxSet, and Person', () => {
-		const settings = {hideDetailsMediaDescription: true};
-		expect(hidesMediaDescription({Type: 'Series'}, settings)).toBe(false);
-		expect(hidesMediaDescription({Type: 'Season'}, settings)).toBe(false);
-		expect(hidesMediaDescription({Type: 'BoxSet'}, settings)).toBe(false);
-		expect(hidesMediaDescription({Type: 'Person'}, settings)).toBe(false);
+	test('a series or a season keeps its description', () => {
+		expect(hidesMediaDescription({Type: 'Series'}, on)).toBe(false);
+		expect(hidesMediaDescription({Type: 'Season'}, on)).toBe(false);
+		expect(hidesMediaDescription({Type: 'BoxSet'}, on)).toBe(false);
+		expect(hidesMediaDescription({Type: 'Person'}, on)).toBe(false);
 	});
 
-	test('returns false when hideDetailsMediaDescription is disabled', () => {
-		const settings = {hideDetailsMediaDescription: false};
-		expect(hidesMediaDescription({Type: 'Movie'}, settings)).toBe(false);
-		expect(hidesMediaDescription({Type: 'Episode'}, settings)).toBe(false);
+	test('music and books keep their description', () => {
+		expect(hidesMediaDescription({Type: 'MusicAlbum'}, on)).toBe(false);
+		expect(hidesMediaDescription({Type: 'MusicArtist'}, on)).toBe(false);
+		expect(hidesMediaDescription({Type: 'Playlist'}, on)).toBe(false);
+		expect(hidesMediaDescription({Type: 'Book'}, on)).toBe(false);
+	});
+
+	test('an unknown or missing type keeps its description', () => {
+		expect(hidesMediaDescription({Type: ''}, on)).toBe(false);
+		expect(hidesMediaDescription({IndexNumber: 1}, on)).toBe(false);
+	});
+
+	test('nothing is held back while the setting is off', () => {
+		const off = {hideDetailsMediaDescription: false};
+		expect(hidesMediaDescription({Type: 'Movie'}, off)).toBe(false);
+		expect(hidesMediaDescription({Type: 'Episode'}, off)).toBe(false);
 	});
 });
 

--- a/packages/app/src/views/Details/detailsMedia.test.js
+++ b/packages/app/src/views/Details/detailsMedia.test.js
@@ -2,9 +2,32 @@
 // English source string, so handing the string straight back is faithful enough here.
 jest.mock('@enact/i18n/$L', () => ({__esModule: true, default: (str) => str}));
 
-import {splitCastAndCrew} from './detailsMedia';
+import {splitCastAndCrew, hidesMediaDescription} from './detailsMedia';
 
 const person = (Id, Name, Type, Role) => ({Id, Name, Type, Role});
+
+describe('hidesMediaDescription', () => {
+	test('returns true for Movie or Episode when hideDetailsMediaDescription is enabled', () => {
+		const settings = {hideDetailsMediaDescription: true};
+		expect(hidesMediaDescription({Type: 'Movie'}, settings)).toBe(true);
+		expect(hidesMediaDescription({Type: 'Episode'}, settings)).toBe(true);
+		expect(hidesMediaDescription({IndexNumber: 1}, settings)).toBe(true);
+	});
+
+	test('returns false for Series, Season, BoxSet, and Person', () => {
+		const settings = {hideDetailsMediaDescription: true};
+		expect(hidesMediaDescription({Type: 'Series'}, settings)).toBe(false);
+		expect(hidesMediaDescription({Type: 'Season'}, settings)).toBe(false);
+		expect(hidesMediaDescription({Type: 'BoxSet'}, settings)).toBe(false);
+		expect(hidesMediaDescription({Type: 'Person'}, settings)).toBe(false);
+	});
+
+	test('returns false when hideDetailsMediaDescription is disabled', () => {
+		const settings = {hideDetailsMediaDescription: false};
+		expect(hidesMediaDescription({Type: 'Movie'}, settings)).toBe(false);
+		expect(hidesMediaDescription({Type: 'Episode'}, settings)).toBe(false);
+	});
+});
 
 describe('splitCastAndCrew', () => {
 	test('actors and guest stars land in the cast', () => {


### PR DESCRIPTION
# Pull Request

## Summary
Extend "Hide Media Description on Details Page" preference to Next Up overviews and episode lists on Smart-TV.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1241 (port of)

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **ModernDetailContent.js** to hide episode overview descriptions in episode rows and inline Next Up cards when `hidesMediaDescription` returns true.
- Updated **SeasonScreen.js** to hide episode overview descriptions in season episode lists when `hidesMediaDescription` returns true.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Toggled "Hide Media Description on Details Page" under Settings -> Personalization -> Details Screen.
2. Verified that episode overviews in episode lists (on Show Main and Season pages) and inline Next Up cards are hidden when enabled.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Before:
<img width="2518" height="1180" alt="2026-08-22_18-04-06_brave" src="https://github.com/user-attachments/assets/724f15fd-f127-4fa2-abdd-3f2dafc24f94" />

After:
<img width="2518" height="1180" alt="2026-08-22_18-05-57_brave" src="https://github.com/user-attachments/assets/cc7bc4e5-61cb-42ef-8193-23e4b71e1c00" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
