### PR TITLE
feat-playback: Porting Rewind

### DIFF
--- a/packages/app/src/views/Player/PlayerControls.js
+++ b/packages/app/src/views/Player/PlayerControls.js
@@ -44,12 +44,8 @@ export const usePlayerButtons = ({
 		}
 		const buttons = [];
 		if (!isLiveTV) {
-			if (hasPrevTrack) {
-				buttons.push(
-					{id: 'previous', icon: <IconPrevious />, label: $L('Previous'), action: 'prevTrack'}
-				);
-			}
 			buttons.push(
+				{id: 'previous', icon: <IconPrevious />, label: $L('Previous'), action: 'prevTrack'},
 				{id: 'rewind', icon: <IconRewind />, label: $L('Seek Back'), action: 'rewind'},
 				{id: 'playPause', icon: isPaused ? <IconPlay /> : <IconPause />, label: isPaused ? $L('Play') : $L('Pause'), action: 'playPause'},
 				{id: 'forward', icon: <IconForward />, label: $L('Seek Forward'), action: 'forward'}

--- a/packages/app/src/views/Player/audio/useAudioTransport.js
+++ b/packages/app/src/views/Player/audio/useAudioTransport.js
@@ -51,12 +51,9 @@ const useAudioTransport = ({
 	}, [audioPlaylist, onPlayNext, isAudioMode, playlistHasNext, audioPlaylistIndex, queue, playQueueTrack, restartCurrent]);
 
 	const handlePrevTrack = useCallback(async () => {
+		// Nothing is queued behind a video, so previous restarts it rather than stepping back.
 		if (!isAudioMode) {
-			if (!audioPlaylist || !onPlayNext || !playlistHasPrev || getPositionSeconds() > 3) {
-				seekTo(0);
-			} else {
-				await playQueueTrack(audioPlaylist[audioPlaylistIndex - 1]);
-			}
+			seekTo(0);
 			return;
 		}
 		if (!audioPlaylist || !onPlayNext) return;
@@ -64,7 +61,7 @@ const useAudioTransport = ({
 		if (!step) return;
 		if (step.type === 'restart') seekTo(0);
 		else await playQueueTrack(step.track);
-	}, [audioPlaylist, onPlayNext, isAudioMode, playlistHasPrev, audioPlaylistIndex, queue, playQueueTrack, getPositionSeconds, seekTo]);
+	}, [audioPlaylist, onPlayNext, isAudioMode, queue, playQueueTrack, getPositionSeconds, seekTo]);
 
 	const handleSelectQueueTrack = useCallback((track) => {
 		if (track?.Id === item?.Id) return;

--- a/packages/app/src/views/Player/audio/useAudioTransport.js
+++ b/packages/app/src/views/Player/audio/useAudioTransport.js
@@ -51,11 +51,15 @@ const useAudioTransport = ({
 	}, [audioPlaylist, onPlayNext, isAudioMode, playlistHasNext, audioPlaylistIndex, queue, playQueueTrack, restartCurrent]);
 
 	const handlePrevTrack = useCallback(async () => {
-		if (!audioPlaylist || !onPlayNext) return;
 		if (!isAudioMode) {
-			if (playlistHasPrev) await playQueueTrack(audioPlaylist[audioPlaylistIndex - 1]);
+			if (!audioPlaylist || !onPlayNext || !playlistHasPrev || getPositionSeconds() > 3) {
+				seekTo(0);
+			} else {
+				await playQueueTrack(audioPlaylist[audioPlaylistIndex - 1]);
+			}
 			return;
 		}
+		if (!audioPlaylist || !onPlayNext) return;
 		const step = queue.getPrev(getPositionSeconds());
 		if (!step) return;
 		if (step.type === 'restart') seekTo(0);


### PR DESCRIPTION
# Pull Request

## Summary
Always render the Previous playback button and fallback to rewinding to start when no previous track exists on Smart-TV.

## Related Issues

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Moonfin-Core/pull/1245 (port of)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Updated **PlayerControls.js** to remove conditional `hasPrevTrack` wrapping around `id: 'previous'` button for non-live TV video playback.
- Updated **useAudioTransport.js** to check `getPositionSeconds() > 3 || !playlistHasPrev` and call `seekTo(0)` when previous is triggered without a previous episode in queue.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
- [ ] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [x] Not tested (explain why): Dinnertime, will test tonight if needed

### Test Steps
1. Launched video playback for S1E1 and a movie.
2. Verified that the Previous button (`IconPrevious`) appears in the transport control bar.
3. Clicked Previous and verified it rewinds playback to 0:00.

## Screenshots (if applicable)

TV SHOW
<img width="2518" height="1176" alt="2026-08-22_21-27-43_brave" src="https://github.com/user-attachments/assets/f43d956a-9b11-4363-af53-2d6fa95bc3a0" />

MOVIE
<img width="2518" height="1176" alt="2026-08-22_21-39-01_brave" src="https://github.com/user-attachments/assets/7dfd3f01-7ebe-4a41-af7f-1258a0adc81e" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
