### PR TITLE
Add subtitle sync timeline to the offset overlay

### DIFF
--- a/packages/app/src/views/Player/Player.module.less
+++ b/packages/app/src/views/Player/Player.module.less
@@ -103,6 +103,72 @@
 	text-align: center;
 }
 
+.offsetModalWide {
+	width: 900px;
+}
+
+.timeline {
+	margin-bottom: 40px;
+}
+
+.timelineRuler {
+	position: relative;
+	height: 26px;
+	margin-bottom: 6px;
+}
+
+.timelineMarker {
+	position: absolute;
+	top: 0;
+	transform: translateX(-50%);
+	font-size: 18px;
+	color: rgba(255, 255, 255, 0.5);
+	white-space: nowrap;
+}
+
+.timelineTrack {
+	position: relative;
+	height: 150px;
+	border-radius: 8px;
+	background: rgba(0, 0, 0, 0.5);
+	border: 2px solid rgba(255, 255, 255, 0.15);
+	overflow: hidden;
+}
+
+.timelineEvent {
+	position: absolute;
+	top: 12px;
+	bottom: 12px;
+	border-radius: 4px;
+	background: rgba(255, 255, 255, 0.22);
+	overflow: hidden;
+}
+
+.timelineEventActive {
+	background: rgba(var(--theme-accent-rgb, 0, 164, 220), 0.55);
+}
+
+.timelineEventText {
+	display: block;
+	padding: 8px 6px;
+	font-size: 18px;
+	line-height: 1.2;
+	color: #fff;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.timelinePlayhead {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	width: 4px;
+	margin-left: -2px;
+	background: #fff;
+	box-shadow: 0 0 8px rgba(0, 0, 0, 0.9);
+}
+
 .offsetActions {
 	display: flex;
 	justify-content: center;

--- a/packages/app/src/views/Player/PlayerControls.js
+++ b/packages/app/src/views/Player/PlayerControls.js
@@ -190,6 +190,7 @@ const PlayerControls = ({
 	chapters,
 	currentTime,
 	subtitleOffset,
+	subtitleTrackEvents,
 	handleControlButtonClick,
 	handleProgressClick,
 	handleProgressKeyDown,
@@ -802,6 +803,8 @@ const PlayerControls = ({
 			<SubtitleOffsetOverlay
 				visible={activeModal === 'subtitleOffset'}
 				currentOffset={subtitleOffset}
+				currentTime={currentTime}
+				subtitleTrackEvents={subtitleTrackEvents}
 				onClose={closeModal}
 				onOffsetChange={handleSubtitleOffsetChange}
 			/>

--- a/packages/app/src/views/Player/SubtitleOffsetOverlay.js
+++ b/packages/app/src/views/Player/SubtitleOffsetOverlay.js
@@ -1,9 +1,10 @@
 import Spottable from '@enact/spotlight/Spottable';
 import SpotlightContainerDecorator from '@enact/spotlight/SpotlightContainerDecorator';
 import Spotlight from '@enact/spotlight';
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import $L from '@enact/i18n/$L';
 import {isBackKey} from '../../utils/keys';
+import {buildSubtitleTimeline} from './subtitleTimeline';
 
 import css from './Player.module.less';
 
@@ -18,7 +19,12 @@ const OffsetContainer = SpotlightContainerDecorator({
 
 const stopPropagation = (e) => e.stopPropagation();
 
-const SubtitleOffsetOverlay = ({visible, currentOffset, onClose, onOffsetChange}) => {
+const SubtitleOffsetOverlay = ({visible, currentOffset, currentTime, subtitleTrackEvents, onClose, onOffsetChange}) => {
+	const timeline = useMemo(
+		() => (visible ? buildSubtitleTimeline(subtitleTrackEvents, currentTime, currentOffset) : null),
+		[visible, subtitleTrackEvents, currentTime, currentOffset]
+	);
+
 	const handleIncrease = useCallback(() => {
 		onOffsetChange(Math.round((currentOffset + 0.1) * 10) / 10);
 	}, [currentOffset, onOffsetChange]);
@@ -59,7 +65,7 @@ const SubtitleOffsetOverlay = ({visible, currentOffset, onClose, onOffsetChange}
 	return (
 		<div className={css.trackModal} onClick={onClose}>
 			<OffsetContainer
-				className={`${css.modalContent} ${css.offsetModal}`}
+				className={`${css.modalContent} ${css.offsetModal}${timeline ? ` ${css.offsetModalWide}` : ''}`}
 				onClick={stopPropagation}
 				spotlightId="offset-modal"
 			>
@@ -83,6 +89,33 @@ const SubtitleOffsetOverlay = ({visible, currentOffset, onClose, onOffsetChange}
 						+
 					</SpottableButton>
 				</div>
+				{timeline ? (
+					<div className={css.timeline}>
+						<div className={css.timelineRuler}>
+							{timeline.markers.map((marker) => (
+								<span
+									key={marker.time}
+									className={css.timelineMarker}
+									style={{left: `${marker.left}%`}}
+								>
+									{marker.label}
+								</span>
+							))}
+						</div>
+						<div className={css.timelineTrack}>
+							{timeline.bars.map((bar) => (
+								<div
+									key={bar.key}
+									className={bar.isActive ? `${css.timelineEvent} ${css.timelineEventActive}` : css.timelineEvent}
+									style={{left: `${bar.left}%`, width: `${bar.width}%`}}
+								>
+									<span className={css.timelineEventText}>{bar.text}</span>
+								</div>
+							))}
+							<div className={css.timelinePlayhead} style={{left: `${timeline.playheadLeft}%`}} />
+						</div>
+					</div>
+				) : null}
 				<div className={css.offsetActions}>
 					<SpottableButton
 						className={css.actionBtn}

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -2739,6 +2739,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				chapters={chapters}
 				currentTime={currentTime}
 				subtitleOffset={subtitleOffset}
+				subtitleTrackEvents={subtitleTrackEvents}
 				handleControlButtonClick={handleControlButtonClick}
 				handleProgressClick={handleProgressClick}
 				handleProgressKeyDown={handleProgressKeyDown}

--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -2619,6 +2619,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 				chapters={chapters}
 				currentTime={currentTime}
 				subtitleOffset={subtitleOffset}
+				subtitleTrackEvents={subtitleTrackEvents}
 				handleControlButtonClick={handleControlButtonClick}
 				handleProgressClick={handleProgressClick}
 				handleProgressKeyDown={handleProgressKeyDown}

--- a/packages/app/src/views/Player/subtitleTimeline.js
+++ b/packages/app/src/views/Player/subtitleTimeline.js
@@ -1,0 +1,59 @@
+const TICKS_PER_SECOND = 10000000;
+const MARKER_INTERVAL_SECONDS = 1;
+const MIN_BAR_WIDTH_PERCENT = 0.4;
+
+export const TIMELINE_WINDOW_SECONDS = 10;
+
+// Bars carry the cue's own words, so ASS override blocks and the markup the
+// text overlay renders have to come off before they reach a text node.
+const toPlainText = (text) => String(text || '')
+	.replace(/\{\\[^}]*\}/g, '')
+	.replace(/<[^>]*>/g, '')
+	.replace(/\s+/g, ' ')
+	.trim();
+
+export const formatTimeMarker = (seconds) => {
+	const minutes = Math.floor(seconds / 60);
+	const secs = Math.floor(seconds % 60);
+	return `${minutes}:${String(secs).padStart(2, '0')}`;
+};
+
+/**
+ * Lays out the subtitle events that fall inside a window centred on the
+ * playhead, as percentages across that window.
+ *
+ * The offset moves the cues, not the playhead, so the bars slide under a fixed
+ * indicator exactly the way the rendered subtitles shift against the picture.
+ */
+export const buildSubtitleTimeline = (events, currentTimeSeconds, offsetSeconds = 0) => {
+	if (!Array.isArray(events) || events.length === 0) return null;
+
+	const currentTime = Number.isFinite(currentTimeSeconds) ? currentTimeSeconds : 0;
+	const windowStart = Math.max(0, currentTime - (TIMELINE_WINDOW_SECONDS / 2));
+	const windowEnd = windowStart + TIMELINE_WINDOW_SECONDS;
+	const percentOf = (time) => ((time - windowStart) / TIMELINE_WINDOW_SECONDS) * 100;
+
+	const markers = [];
+	for (let time = Math.ceil(windowStart); time <= windowEnd; time += MARKER_INTERVAL_SECONDS) {
+		markers.push({time, label: formatTimeMarker(time), left: percentOf(time)});
+	}
+
+	const bars = [];
+	for (const event of events) {
+		const start = (event.StartPositionTicks / TICKS_PER_SECOND) + offsetSeconds;
+		const end = (event.EndPositionTicks / TICKS_PER_SECOND) + offsetSeconds;
+		if (end <= windowStart || start >= windowEnd) continue;
+
+		const left = Math.max(0, percentOf(start));
+		const width = Math.min(100, percentOf(end)) - left;
+		bars.push({
+			key: `${event.StartPositionTicks}-${event.EndPositionTicks}`,
+			left,
+			width: Math.max(width, MIN_BAR_WIDTH_PERCENT),
+			text: toPlainText(event.Text),
+			isActive: currentTime >= start && currentTime <= end
+		});
+	}
+
+	return {markers, bars, playheadLeft: percentOf(currentTime)};
+};

--- a/packages/app/src/views/Player/subtitleTimeline.test.js
+++ b/packages/app/src/views/Player/subtitleTimeline.test.js
@@ -1,0 +1,78 @@
+import {buildSubtitleTimeline, formatTimeMarker, TIMELINE_WINDOW_SECONDS} from './subtitleTimeline';
+
+const TICKS_PER_SECOND = 10000000;
+const event = (start, end, text = 'line') => ({
+	StartPositionTicks: start * TICKS_PER_SECOND,
+	EndPositionTicks: end * TICKS_PER_SECOND,
+	Text: text
+});
+
+describe('formatTimeMarker', () => {
+	it('pads the seconds', () => {
+		expect(formatTimeMarker(65)).toBe('1:05');
+		expect(formatTimeMarker(0)).toBe('0:00');
+	});
+});
+
+describe('buildSubtitleTimeline', () => {
+	it('returns null when there are no events to draw', () => {
+		expect(buildSubtitleTimeline(null, 10)).toBeNull();
+		expect(buildSubtitleTimeline([], 10)).toBeNull();
+	});
+
+	it('drops events outside the window', () => {
+		const events = [event(0, 1), event(59, 61), event(200, 202)];
+
+		const {bars} = buildSubtitleTimeline(events, 60);
+
+		expect(bars).toHaveLength(1);
+		expect(bars[0].text).toBe('line');
+	});
+
+	it('centres the playhead once the window clears the start of the file', () => {
+		expect(buildSubtitleTimeline([event(59, 61)], 60).playheadLeft).toBe(50);
+	});
+
+	it('keeps the playhead against the real time near the start of the file', () => {
+		// The window cannot start before 0, so the playhead sits where it lands.
+		expect(buildSubtitleTimeline([event(0, 2)], 1).playheadLeft).toBe(10);
+	});
+
+	it('shifts the bars by the offset and leaves the playhead alone', () => {
+		const withoutOffset = buildSubtitleTimeline([event(59, 61)], 60);
+		const withOffset = buildSubtitleTimeline([event(59, 61)], 60, 1);
+
+		expect(withOffset.bars[0].left - withoutOffset.bars[0].left).toBeCloseTo(10);
+		expect(withOffset.playheadLeft).toBe(withoutOffset.playheadLeft);
+	});
+
+	it('marks the event under the playhead as active, offset included', () => {
+		expect(buildSubtitleTimeline([event(59, 61)], 60).bars[0].isActive).toBe(true);
+		expect(buildSubtitleTimeline([event(59, 61)], 60, 5).bars[0].isActive).toBe(false);
+	});
+
+	it('clips a bar that runs past either edge of the window', () => {
+		const {bars} = buildSubtitleTimeline([event(0, 120)], 60);
+
+		expect(bars[0].left).toBe(0);
+		expect(bars[0].width).toBe(100);
+	});
+
+	it('gives a zero-length event enough width to stay visible', () => {
+		expect(buildSubtitleTimeline([event(60, 60)], 60).bars[0].width).toBeGreaterThan(0);
+	});
+
+	it('strips ASS override blocks and markup from the bar text', () => {
+		const events = [event(59, 61, '{\\an8}<i>Hello</i>\nthere')];
+
+		expect(buildSubtitleTimeline(events, 60).bars[0].text).toBe('Hello there');
+	});
+
+	it('spans the window with one marker a second', () => {
+		const {markers} = buildSubtitleTimeline([event(59, 61)], 60);
+
+		expect(markers).toHaveLength(TIMELINE_WINDOW_SECONDS + 1);
+		expect(markers[0].label).toBe('0:55');
+		expect(markers[0].left).toBe(0);
+	});
+});


### PR DESCRIPTION
# Pull Request

## Summary
Draws the subtitle cues around the playhead inside the existing subtitle offset overlay, so the correct offset is visible instead of found by trial. Port of jellyfin/jellyfin-web#6735 to Enact. Its limited to external subtitles as ASS or PGS don't expose subtitle tracks

## Related Issues
- Closes #315

## Type of Change
- [x] New feature

## Changes Made
- `subtitleTimeline.js` — pure helper laying out a 10s window centred on the playhead as percentages, with unit tests.
- `SubtitleOffsetOverlay.js` — renders the ruler, cue bars and playhead when there are cues; unchanged when there are none.
- `Player.module.less` — timeline styles, within the chrome 38 / safari 7 floor.
- `PlayerControls.js`, `WebOSPlayer.js`, `TizenPlayer.js` — pass the already-fetched `subtitleTrackEvents` through.

## Platform
- [x] Both / Shared code

## Testing
- [x] Manual testing completed
- [ ] Tested on physical device (explain why): Didn't spend the time understanding how to build an apk that I could push to the TV

### Test Steps
1. Play an item with a text subtitle track (SRT or an embedded text track).
2. Open the subtitle offset overlay from the player controls.
3. Adjust the offset and confirm the cue bars slide under the fixed playhead while the ruler stays put.
4. Repeat with a styled ASS track and a PGS track — the overlay should look exactly as it does today.

## Screenshots (if applicable)
<img width="2027" height="1343" alt="image" src="https://github.com/user-attachments/assets/fe2d3d9b-b8ea-451d-ba0c-dcfb24740819" />


## Checklist
- [x] Code builds successfully (`enact pack -p`, `check-legacy-css`)
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

Written with Claude Code.
