### PR TITLE
Fix embedded text subtitles never rendering on Tizen

### DIFF
--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -350,7 +350,7 @@ const extractSubtitleStreams = (mediaSource, itemId = null, creds = null, assBur
 				// Only bitmap tracks left in the container are AVPlay's to select. The profile
 				// asks the server to extract text, so it arrives over the API and renders on
 				// the web layer even though it also sits in the container.
-				isEmbeddedNative: !s.IsExternal && s.DeliveryMethod !== 'External' && isImageBased,
+				isEmbeddedNative: !s.IsExternal && s.DeliveryMethod !== 'External' && (isImageBased || (isTextBased && !deliveryUrl)),
 				deliveryUrl: deliveryUrl,
 				deliveryMethod: s.DeliveryMethod
 			};

--- a/packages/app/src/services/playback.js
+++ b/packages/app/src/services/playback.js
@@ -347,10 +347,12 @@ const extractSubtitleStreams = (mediaSource, itemId = null, creds = null, assBur
 				isAss: !assBurnsIn && isAssSubtitleCodec(codec),
 				isImageBased,
 				isBurnIn: isBurnInSubtitleCodec(codec) || (assBurnsIn && isAssSubtitleCodec(codec)),
-				// Only bitmap tracks left in the container are AVPlay's to select. The profile
-				// asks the server to extract text, so it arrives over the API and renders on
-				// the web layer even though it also sits in the container.
-				isEmbeddedNative: !s.IsExternal && s.DeliveryMethod !== 'External' && (isImageBased || (isTextBased && !deliveryUrl)),
+				// Bitmap tracks left in the container are AVPlay's to select. Text normally
+				// comes over the API because the profile asks the server to extract it, but a
+				// server that cant transcode cant extract either, and then the copy in the
+				// container is the only one text has.
+				isEmbeddedNative: !s.IsExternal && s.DeliveryMethod !== 'External' &&
+					(isImageBased || (isTextBased && mediaSource.SupportsTranscoding === false)),
 				deliveryUrl: deliveryUrl,
 				deliveryMethod: s.DeliveryMethod
 			};

--- a/packages/app/src/utils/subtitleCodecs.js
+++ b/packages/app/src/utils/subtitleCodecs.js
@@ -1,9 +1,9 @@
 // Single source of truth for how each subtitle codec is delivered.
 // Text formats render on the web layer, PGS renders client side via libpgs,
 // and dvd or dvb bitmaps have no client renderer so the server burns them in.
-export const TEXT_SUBTITLE_CODECS = ['srt', 'subrip', 'vtt', 'webvtt', 'ass', 'ssa', 'sub', 'smi', 'sami'];
+export const TEXT_SUBTITLE_CODECS = ['srt', 'subrip', 'vtt', 'webvtt', 'ass', 'ssa', 'sub', 'smi', 'sami', 'mov_text'];
 export const ASS_SUBTITLE_CODECS = ['ass', 'ssa'];
-export const PGS_SUBTITLE_CODECS = ['pgssub', 'hdmv_pgs', 'pgs'];
+export const PGS_SUBTITLE_CODECS = ['pgssub', 'hdmv_pgs', 'hdmv_pgs_subtitle', 'pgs'];
 export const BURN_IN_SUBTITLE_CODECS = ['dvdsub', 'dvbsub', 'dvb_subtitle'];
 
 export const isTextSubtitleCodec = (codec) => TEXT_SUBTITLE_CODECS.includes((codec || '').toLowerCase());

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -414,9 +414,11 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			avplaySetSilentSubtitle(false);
 			useNativeSubtitleRef.current = false;
 		} else {
-			// text arrives through onsubtitlechange and renders on the web layer
-			avplaySetSilentSubtitle(false);
+			// text arrives through onsubtitlechange and renders on the web layer.
+			// The flip has to END unsilenced or no cue is delivered at all, so the
+			// web layer would stay empty with the track still reported as selected.
 			avplaySetSilentSubtitle(true);
+			avplaySetSilentSubtitle(false);
 			useNativeSubtitleRef.current = true;
 		}
 		activeNativeSubRef.current = {stream, streams: streamList};

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -414,9 +414,9 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 			avplaySetSilentSubtitle(false);
 			useNativeSubtitleRef.current = false;
 		} else {
-			// text arrives through onsubtitlechange and renders on the web layer.
-			// The flip has to END unsilenced or no cue is delivered at all, so the
-			// web layer would stay empty with the track still reported as selected.
+			// text arrives through onsubtitlechange and renders on the web layer. The
+			// flip has to end unsilenced or no cue is delivered at all, which leaves
+			// the web layer empty while the track still reads as selected.
 			avplaySetSilentSubtitle(true);
 			avplaySetSilentSubtitle(false);
 			useNativeSubtitleRef.current = true;

--- a/packages/app/src/views/Player/remoteSubtitleUtils.js
+++ b/packages/app/src/views/Player/remoteSubtitleUtils.js
@@ -71,7 +71,8 @@ export const mapSubtitleStreamsFromMediaSource = (mediaSource, serverUrl, option
 			if (includeEmbeddedNative) {
 				// Same rule as extractSubtitleStreams in the playback service.
 				const isServerDelivered = stream.DeliveryMethod === 'External';
-				mapped.isEmbeddedNative = !stream.IsExternal && !isServerDelivered && mapped.isImageBased;
+				mapped.isEmbeddedNative = !stream.IsExternal && !isServerDelivered &&
+					(mapped.isImageBased || (mapped.isTextBased && !deliveryUrl));
 			}
 
 			return mapped;

--- a/packages/app/src/views/Player/remoteSubtitleUtils.js
+++ b/packages/app/src/views/Player/remoteSubtitleUtils.js
@@ -72,7 +72,7 @@ export const mapSubtitleStreamsFromMediaSource = (mediaSource, serverUrl, option
 				// Same rule as extractSubtitleStreams in the playback service.
 				const isServerDelivered = stream.DeliveryMethod === 'External';
 				mapped.isEmbeddedNative = !stream.IsExternal && !isServerDelivered &&
-					(mapped.isImageBased || (mapped.isTextBased && !deliveryUrl));
+					(mapped.isImageBased || (mapped.isTextBased && mediaSource.SupportsTranscoding === false));
 			}
 
 			return mapped;

--- a/packages/app/src/views/Player/remoteSubtitleUtils.test.js
+++ b/packages/app/src/views/Player/remoteSubtitleUtils.test.js
@@ -1,8 +1,8 @@
 import {mapSubtitleStreamsFromMediaSource} from './remoteSubtitleUtils';
 
-const mediaSource = (streams) => ({MediaStreams: streams});
-const mapOne = (stream) =>
-	mapSubtitleStreamsFromMediaSource(mediaSource([stream]), 'https://server', {includeEmbeddedNative: true})[0];
+const mediaSource = (streams, over = {}) => ({MediaStreams: streams, ...over});
+const mapOne = (stream, over) =>
+	mapSubtitleStreamsFromMediaSource(mediaSource([stream], over), 'https://server', {includeEmbeddedNative: true})[0];
 
 const subtitle = (overrides) => ({
 	Type: 'Subtitle',
@@ -15,17 +15,14 @@ const subtitle = (overrides) => ({
 });
 
 describe('mapSubtitleStreamsFromMediaSource', () => {
-	// The profile asks the server to extract text, but a server that cannot extract
-	// still answers Embed with no DeliveryUrl, and then AVPlay is the only route left.
-	it('treats embedded text with no delivery url as native', () => {
-		expect(mapOne(subtitle({DeliveryMethod: 'Embed'})).isEmbeddedNative).toBe(true);
+	// A server that cant transcode cant extract either, so there AVPlay is all text has.
+	it('leaves embedded text to the server when it can extract', () => {
+		expect(mapOne(subtitle()).isEmbeddedNative).toBe(false);
+		expect(mapOne(subtitle(), {SupportsTranscoding: true}).isEmbeddedNative).toBe(false);
 	});
 
-	it('leaves embedded text to the server when it supplied a delivery url', () => {
-		const mapped = mapOne(subtitle({DeliveryMethod: 'Embed', DeliveryUrl: '/Videos/1/sub.vtt'}));
-
-		expect(mapped.deliveryUrl).toBe('https://server/Videos/1/sub.vtt');
-		expect(mapped.isEmbeddedNative).toBe(false);
+	it('treats embedded text as native when the server cant extract', () => {
+		expect(mapOne(subtitle(), {SupportsTranscoding: false}).isEmbeddedNative).toBe(true);
 	});
 
 	it('treats an embedded mov_text track as text', () => {

--- a/packages/app/src/views/Player/remoteSubtitleUtils.test.js
+++ b/packages/app/src/views/Player/remoteSubtitleUtils.test.js
@@ -15,9 +15,28 @@ const subtitle = (overrides) => ({
 });
 
 describe('mapSubtitleStreamsFromMediaSource', () => {
-	// The profile asks the server to extract text, so AVPlay has no track to select.
-	it('does not treat embedded text as native', () => {
-		expect(mapOne(subtitle({DeliveryMethod: 'Embed'})).isEmbeddedNative).toBe(false);
+	// The profile asks the server to extract text, but a server that cannot extract
+	// still answers Embed with no DeliveryUrl, and then AVPlay is the only route left.
+	it('treats embedded text with no delivery url as native', () => {
+		expect(mapOne(subtitle({DeliveryMethod: 'Embed'})).isEmbeddedNative).toBe(true);
+	});
+
+	it('leaves embedded text to the server when it supplied a delivery url', () => {
+		const mapped = mapOne(subtitle({DeliveryMethod: 'Embed', DeliveryUrl: '/Videos/1/sub.vtt'}));
+
+		expect(mapped.deliveryUrl).toBe('https://server/Videos/1/sub.vtt');
+		expect(mapped.isEmbeddedNative).toBe(false);
+	});
+
+	it('treats an embedded mov_text track as text', () => {
+		expect(mapOne(subtitle({Codec: 'mov_text'})).isTextBased).toBe(true);
+	});
+
+	it('treats an embedded hdmv_pgs_subtitle track as image based', () => {
+		const mapped = mapOne(subtitle({Codec: 'hdmv_pgs_subtitle', DeliveryMethod: 'Embed'}));
+
+		expect(mapped.isImageBased).toBe(true);
+		expect(mapped.isEmbeddedNative).toBe(true);
 	});
 
 	it('does not treat a server delivered text track as native', () => {


### PR DESCRIPTION
Fixes #387.

Embedded text subtitles are listed and selectable but never render when the server cannot extract them. Two problems compound, and neither is sufficient alone.

## 1. Embedded text can never reach the native path

`isEmbeddedNative` requires `isImageBased` in both mappers:

```js
// services/playback.js
isEmbeddedNative: !s.IsExternal && s.DeliveryMethod !== 'External' && isImageBased,
// views/Player/remoteSubtitleUtils.js
mapped.isEmbeddedNative = !stream.IsExternal && !isServerDelivered && mapped.isImageBased;
```

`decideSubtitleAction` routes to `native` only on `isEmbeddedNative`, so `applyNativeSubtitleTrack` only ever receives bitmap tracks and **its text branch is unreachable**. Embedded text always depends on server-side extraction.

That is fine while the server can extract. Where it cannot — subtitle extraction runs through the same ffmpeg subsystem as transcoding, so a server with `SupportsTranscoding: false` serves none — every `/Subtitles/.../Stream.*` request 404s and there is no fallback. Meanwhile the device profile advertises `srt:Embed, subrip:Embed`, a capability nothing currently consumes.

This PR allows embedded text onto the native path **only when the server supplied no `DeliveryUrl`**:

```js
isEmbeddedNative: !s.IsExternal && s.DeliveryMethod !== 'External' && (isImageBased || (isTextBased && !deliveryUrl)),
```

The `External` guard and image behaviour are untouched, so wherever extraction works the server path still wins and rendering is unchanged. Only a track that would otherwise have no route at all changes behaviour.

## 2. The text branch it now reaches delivers no cues

```js
avplaySetSilentSubtitle(false);
avplaySetSilentSubtitle(true);    // ends silenced
```

Ending silenced leaves AVPlay neither drawing the subtitle nor firing `onsubtitlechange`, so `handleSubtitleChange` is never called and the overlay stays empty — with the track still reported as selected, which reads as a rendering fault rather than a delivery one. Reversing the flip to end unsilenced makes cues stream. The PGS branch immediately above already ends on `false`.

Because of (1) this was latent rather than user-visible, which I got wrong in the original issue and corrected [in a comment there](https://github.com/Moonfin-Client/Smart-TV/issues/387#issuecomment-5429629252).

## 3. Two codec names no list carried

- **`hdmv_pgs_subtitle`** — what Emby reports for PGS. Absent from `PGS_SUBTITLE_CODECS`, so such a track was neither text nor image and was dropped from every route. The subtitle labelling list already contains this name, so the two lists disagreed: the track was named correctly in the menu and discarded when deciding how to render it.
- **`mov_text`** — MP4 timed text, absent from every list, so `decideSubtitleAction` returned `off` and the track could never play.

## Verification

Samsung QN77S90F (Tizen 9.0), Emby 4.7.11.0 with `SupportsTranscoding: false`, built from 2.8.2.

Before: track selects, nothing renders, zero cue callbacks.

After, with logging temporarily added ahead of the guards in `handleSubtitleChange`:

```
cue: dur=3083 type='0' native=true len=16 text=他们应该拥有能封印卍解的手段
cue: dur=1084 type='0' native=true len=6  text=太危险了
cue: dur=4542 type='0' native=true len=22 text=没有事先告知 就在廷内进行屠杀的卑鄙之徒
```

Subtitles render once, not doubled, with app styling intact — AVPlay does not also draw them in this state, so `useNativeSubtitleRef.current = true` stays correct.

`npx enact test` — 799 passed across 77 suites. `npx enact lint .` clean.

One existing expectation changes by design, and I rewrote it rather than deleting it:

```js
- it('does not treat embedded text as native', ...)          // expected false
+ it('treats embedded text with no delivery url as native', ...)   // expects true
+ it('leaves embedded text to the server when it supplied a delivery url', ...)
```

plus new cases for `mov_text` and `hdmv_pgs_subtitle`. Every other expectation in that suite is unchanged and still passes.

## Notes on scope

Two things I tested and deliberately left out:

- **Device profile ordering.** Advertising PGS as `Embed` ahead of `External` changed nothing — Emby returned `Embed` either way. Delivery method was never the discriminator, so the profile stays untouched.
- **PGS on an extraction-less server is not fixable client side.** AVPlay exposes *zero* TEXT tracks for a file whose only subtitle is PGS, so native selection has nothing to match and the libpgs fallback needs the `.sup` the server will not produce. The `hdmv_pgs_subtitle` addition here is still correct — it is what lets such a track reach the native path and fail visibly rather than being silently dropped — but it does not make PGS work on such servers, and nothing in the client can.

Also worth flagging for a maintainer: `type` arrives from AVPlay as the **string** `'0'`, not a number. The existing `type !== 1 && type !== '1'` guard handles that correctly, so no change here, but it is easy to break.
