### PR TITLE
perf(search): reduce rendering and artwork overhead

### DIFF
--- a/packages/app/src/views/Search/Search.js
+++ b/packages/app/src/views/Search/Search.js
@@ -20,6 +20,12 @@ import {isGameLibrary, resolveGameLibraryId} from '../../utils/gameLibrary';
 import {groupSearchResults, aspectClassForType, isCircleType, filterByName, fetchAllGames, filterGames} from '../../utils/searchGroups';
 import SpottableInput from '../../components/SpottableInput/SpottableInput';
 import useStorage from '../../hooks/useStorage';
+import {
+	initialCardCount,
+	expandedCardCount,
+	searchArtworkOptions,
+	shouldMountSearchRow
+} from './searchWindow';
 
 import css from './Search.module.less';
 
@@ -84,6 +90,8 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 	const [seerrResults, setSeerrResults] = useState([]);
 	const [gameResults, setGameResults] = useState([]);
 	const [activeTab, setActiveTab] = useState('all');
+	const [activeRowIndex, setActiveRowIndex] = useState(0);
+	const [visibleCardCounts, setVisibleCardCounts] = useState({});
 	const [recentSearches, saveRecentSearches] = useStorage(RECENT_SEARCHES_KEY, []);
 
 	// doSearch records into this list, so it reads the current value through a
@@ -148,6 +156,8 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 			setGroups([]);
 			setSeerrResults([]);
 			setGameResults([]);
+			setActiveRowIndex(0);
+			setVisibleCardCounts({});
 			return;
 		}
 
@@ -169,6 +179,8 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 			const items = [...(libraryResult.Items || []), ...filterByName(channels, q)];
 			lastResultNamesRef.current = items.map((found) => found.Name).filter(Boolean);
 			setGroups(groupSearchResults(items));
+			setActiveRowIndex(0);
+			setVisibleCardCounts({});
 			setIsLoading(false);
 			rememberSearch(q);
 			// A new query always starts on All. Focus it once the tabs render, unless
@@ -230,6 +242,8 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 		setGroups([]);
 		setSeerrResults([]);
 		setGameResults([]);
+		setActiveRowIndex(0);
+		setVisibleCardCounts({});
 		Spotlight.focus('search-input');
 	}, []);
 
@@ -311,6 +325,7 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 	}, [focusBelowInput]);
 
 	const focusContent = useCallback(() => {
+		if (activeTab === 'all') setActiveRowIndex(0);
 		Spotlight.focus(activeTab === 'all' ? 'search-row-0' : 'search-grid');
 	}, [activeTab]);
 
@@ -334,19 +349,38 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 		if (e.keyCode === KEYS.UP) {
 			e.preventDefault();
 			e.stopPropagation();
-			Spotlight.focus(rowIndex === 0 ? 'search-tabs' : `search-row-${rowIndex - 1}`);
+			if (rowIndex === 0) {
+				Spotlight.focus('search-tabs');
+			} else {
+				setActiveRowIndex(rowIndex - 1);
+				Spotlight.focus(`search-row-${rowIndex - 1}`);
+			}
 		} else if (e.keyCode === KEYS.DOWN) {
 			e.preventDefault();
 			e.stopPropagation();
-			if (rowIndex < allRows.length - 1) Spotlight.focus(`search-row-${rowIndex + 1}`);
+			if (rowIndex < allRows.length - 1) {
+				setActiveRowIndex(rowIndex + 1);
+				Spotlight.focus(`search-row-${rowIndex + 1}`);
+			}
 		}
 	}, [allRows.length]);
 
-	const handleRowFocus = useCallback((rowId) => (e) => {
+	const handleRowFocus = useCallback((rowId, rowIndex, itemCount) => (e) => {
 		if (pointerHover()) return;
+		setActiveRowIndex((current) => current === rowIndex ? current : rowIndex);
 		const card = e.target.closest('[data-spotlight-id]');
 		const scroller = scrollerRefs.current[rowId];
 		if (!card || !scroller) return;
+		const spotlightId = card.getAttribute('data-spotlight-id') || '';
+		const indexMatch = /-item-(\d+)$/.exec(spotlightId);
+		if (indexMatch) {
+			const focusedIndex = parseInt(indexMatch[1], 10);
+			setVisibleCardCounts((current) => {
+				const visible = current[rowId] || initialCardCount(itemCount);
+				const expanded = expandedCardCount(visible, focusedIndex, itemCount);
+				return expanded === visible ? current : {...current, [rowId]: expanded};
+			});
+		}
 		const cardRect = card.getBoundingClientRect();
 		const scrollerRect = scroller.getBoundingClientRect();
 		if (cardRect.left < scrollerRect.left) {
@@ -387,13 +421,22 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 	const handleGameSelect = useCallback((game) => onSelectGame?.(game._library, game), [onSelectGame]);
 
 	const renderJellyfinCard = useCallback((item, spotlightId) => {
+		const aspect = aspectClassForType(item.Type);
 		const {card, img} = cardSizeClass(item.Type);
 		const circle = isCircleType(item.Type);
 		const itemServerUrl = item._serverUrl || serverUrl;
 		const hasImage = item.ImageTags?.Primary || item.PrimaryImageTag;
-		let imageUrl = hasImage ? getImageUrl(itemServerUrl, item.Id, 'Primary') : null;
+		const primaryTag = item.ImageTags?.Primary || item.PrimaryImageTag;
+		let imageUrl = hasImage
+			? getImageUrl(itemServerUrl, item.Id, 'Primary', searchArtworkOptions(aspect, primaryTag))
+			: null;
 		if (!imageUrl && item.Type === 'Audio' && item.AlbumId && item.AlbumPrimaryImageTag) {
-			imageUrl = getImageUrl(itemServerUrl, item.AlbumId, 'Primary');
+			imageUrl = getImageUrl(
+				itemServerUrl,
+				item.AlbumId,
+				'Primary',
+				searchArtworkOptions(aspect, item.AlbumPrimaryImageTag)
+			);
 		}
 		return (
 			<SpottableDiv
@@ -475,7 +518,12 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 		if (activeTab === 'all') {
 			return (
 				<div className={css.resultsContainer}>
-					{allRows.map((row, rowIndex) => (
+					{allRows.map((row, rowIndex) => {
+						const mounted = shouldMountSearchRow(rowIndex, activeRowIndex);
+						const visibleCount = visibleCardCounts[row.id] || initialCardCount(row.items.length);
+						const firstType = row.kind === 'jellyfin' ? row.items[0]?.Type : 'Movie';
+						const placeholderSize = cardSizeClass(firstType);
+						return (
 						<RowContainer
 							key={row.id}
 							className={css.resultRow}
@@ -487,14 +535,25 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 							<div
 								className={css.rowScroller}
 								ref={(el) => { scrollerRefs.current[row.id] = el; }}
-								onFocus={handleRowFocus(row.id)}
+								onFocus={handleRowFocus(row.id, rowIndex, row.items.length)}
 							>
-								<div className={css.resultItems}>
-									{row.items.map((item, idx) => renderCard(row.kind, item, `${row.id}-item-${idx}`))}
-								</div>
+								{mounted ? (
+									<div className={css.resultItems}>
+										{row.items.slice(0, visibleCount).map((item, idx) => renderCard(row.kind, item, `${row.id}-item-${idx}`))}
+									</div>
+								) : (
+									<div className={css.resultItems} aria-hidden="true">
+										<div className={`${css.card} ${placeholderSize.card} ${css.windowPlaceholder}`}>
+											<div className={`${css.cardImg} ${placeholderSize.img}`} />
+											<div className={css.cardTitle}>&nbsp;</div>
+											<div className={css.cardSubtitle}>&nbsp;</div>
+										</div>
+									</div>
+								)}
 							</div>
 						</RowContainer>
-					))}
+						);
+					})}
 				</div>
 			);
 		}

--- a/packages/app/src/views/Search/Search.js
+++ b/packages/app/src/views/Search/Search.js
@@ -55,10 +55,16 @@ const SearchIcon = () => (
 
 const cardSizeClass = (type) => {
 	const aspect = aspectClassForType(type);
-	if (aspect === 'wide') return {card: css.cardWide, img: css.imgWide};
-	if (aspect === 'square') return {card: css.cardSquare, img: css.imgSquare};
-	return {card: css.cardPoster, img: css.imgPoster};
+	if (aspect === 'wide') return {aspect, card: css.cardWide, img: css.imgWide};
+	if (aspect === 'square') return {aspect, card: css.cardSquare, img: css.imgSquare};
+	return {aspect, card: css.cardPoster, img: css.imgPoster};
 };
+
+// An unmounted row still has to hold its height, so it draws one hidden card in
+// the shape that row uses. Games come from GameCard, which sizes itself.
+const placeholderShape = (row) => row.kind === 'game'
+	? {card: css.cardGame, img: css.imgGame}
+	: cardSizeClass(row.kind === 'jellyfin' ? row.items[0]?.Type : 'Movie');
 
 const jellyfinSubtitle = (item) => {
 	switch (item.Type) {
@@ -421,13 +427,11 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 	const handleGameSelect = useCallback((game) => onSelectGame?.(game._library, game), [onSelectGame]);
 
 	const renderJellyfinCard = useCallback((item, spotlightId) => {
-		const aspect = aspectClassForType(item.Type);
-		const {card, img} = cardSizeClass(item.Type);
+		const {aspect, card, img} = cardSizeClass(item.Type);
 		const circle = isCircleType(item.Type);
 		const itemServerUrl = item._serverUrl || serverUrl;
-		const hasImage = item.ImageTags?.Primary || item.PrimaryImageTag;
 		const primaryTag = item.ImageTags?.Primary || item.PrimaryImageTag;
-		let imageUrl = hasImage
+		let imageUrl = primaryTag
 			? getImageUrl(itemServerUrl, item.Id, 'Primary', searchArtworkOptions(aspect, primaryTag))
 			: null;
 		if (!imageUrl && item.Type === 'Audio' && item.AlbumId && item.AlbumPrimaryImageTag) {
@@ -520,38 +524,37 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 				<div className={css.resultsContainer}>
 					{allRows.map((row, rowIndex) => {
 						const mounted = shouldMountSearchRow(rowIndex, activeRowIndex);
-						const visibleCount = visibleCardCounts[row.id] || initialCardCount(row.items.length);
-						const firstType = row.kind === 'jellyfin' ? row.items[0]?.Type : 'Movie';
-						const placeholderSize = cardSizeClass(firstType);
+						const visibleCount = mounted ? visibleCardCounts[row.id] || initialCardCount(row.items.length) : 0;
+						const placeholderSize = mounted ? null : placeholderShape(row);
 						return (
-						<RowContainer
-							key={row.id}
-							className={css.resultRow}
-							spotlightId={`search-row-${rowIndex}`}
-							data-row-index={rowIndex}
-							onKeyDown={handleRowKeyDown}
-						>
-							<h2 className={css.rowTitle}>{row.title}<span className={css.rowCount}> ({row.items.length})</span></h2>
-							<div
-								className={css.rowScroller}
-								ref={(el) => { scrollerRefs.current[row.id] = el; }}
-								onFocus={handleRowFocus(row.id, rowIndex, row.items.length)}
+							<RowContainer
+								key={row.id}
+								className={css.resultRow}
+								spotlightId={`search-row-${rowIndex}`}
+								data-row-index={rowIndex}
+								onKeyDown={handleRowKeyDown}
 							>
-								{mounted ? (
-									<div className={css.resultItems}>
-										{row.items.slice(0, visibleCount).map((item, idx) => renderCard(row.kind, item, `${row.id}-item-${idx}`))}
-									</div>
-								) : (
-									<div className={css.resultItems} aria-hidden="true">
-										<div className={`${css.card} ${placeholderSize.card} ${css.windowPlaceholder}`}>
-											<div className={`${css.cardImg} ${placeholderSize.img}`} />
-											<div className={css.cardTitle}>&nbsp;</div>
-											<div className={css.cardSubtitle}>&nbsp;</div>
+								<h2 className={css.rowTitle}>{row.title}<span className={css.rowCount}> ({row.items.length})</span></h2>
+								<div
+									className={css.rowScroller}
+									ref={(el) => { scrollerRefs.current[row.id] = el; }}
+									onFocus={handleRowFocus(row.id, rowIndex, row.items.length)}
+								>
+									{mounted ? (
+										<div className={css.resultItems}>
+											{row.items.slice(0, visibleCount).map((item, idx) => renderCard(row.kind, item, `${row.id}-item-${idx}`))}
 										</div>
-									</div>
-								)}
-							</div>
-						</RowContainer>
+									) : (
+										<div className={css.resultItems} aria-hidden="true">
+											<div className={`${css.card} ${placeholderSize.card} ${css.windowPlaceholder}`}>
+												<div className={`${css.cardImg} ${placeholderSize.img}`} />
+												<div className={css.cardTitle}>&nbsp;</div>
+												<div className={css.cardSubtitle}>&nbsp;</div>
+											</div>
+										</div>
+									)}
+								</div>
+							</RowContainer>
 						);
 					})}
 				</div>

--- a/packages/app/src/views/Search/Search.module.less
+++ b/packages/app/src/views/Search/Search.module.less
@@ -326,6 +326,11 @@
 	color: rgba(var(--theme-on-surface-rgb, 255, 255, 255), 0.2);
 }
 
+.windowPlaceholder {
+	visibility: hidden;
+	pointer-events: none;
+}
+
 .watchedBadge {
 	@import '../../styles/mixins.less';
 	.watched-badge(24px, 14px);

--- a/packages/app/src/views/Search/Search.module.less
+++ b/packages/app/src/views/Search/Search.module.less
@@ -331,6 +331,17 @@
 	pointer-events: none;
 }
 
+// GameCard sizes itself rather than using the card classes above, so the stand
+// in for an unmounted games row has to match its width and poster ratio or the
+// row changes height as it mounts.
+.cardGame {
+	width: 150px;
+}
+
+.imgGame {
+	padding-top: 134%;
+}
+
 .watchedBadge {
 	@import '../../styles/mixins.less';
 	.watched-badge(24px, 14px);

--- a/packages/app/src/views/Search/searchWindow.js
+++ b/packages/app/src/views/Search/searchWindow.js
@@ -1,5 +1,9 @@
+// A row opens with about a screen of cards and grows as focus nears the end of
+// what is mounted, so a long result set is only built in full for someone who
+// walks through it.
 export const INITIAL_CARD_WINDOW = 10;
 export const CARD_WINDOW_STEP = 8;
+// How near the last mounted card focus has to get before the next batch lands.
 export const CARD_WINDOW_EDGE = 2;
 export const ROW_WINDOW_RADIUS = 1;
 
@@ -17,6 +21,8 @@ export const expandedCardCount = (currentCount, focusedIndex, itemCount) => {
 };
 
 export const searchArtworkOptions = (aspect, tag) => {
-	const size = aspect === 'poster' ? {maxHeight: 360} : {maxWidth: 440};
-	return tag ? {...size, quality: 75, tag} : {...size, quality: 75};
+	const options = aspect === 'poster' ? {maxHeight: 300} : {maxWidth: 400};
+	options.quality = 80;
+	if (tag) options.tag = tag;
+	return options;
 };

--- a/packages/app/src/views/Search/searchWindow.js
+++ b/packages/app/src/views/Search/searchWindow.js
@@ -1,0 +1,22 @@
+export const INITIAL_CARD_WINDOW = 10;
+export const CARD_WINDOW_STEP = 8;
+export const CARD_WINDOW_EDGE = 2;
+export const ROW_WINDOW_RADIUS = 1;
+
+export const shouldMountSearchRow = (rowIndex, activeRowIndex) =>
+	Math.abs(rowIndex - activeRowIndex) <= ROW_WINDOW_RADIUS;
+
+export const initialCardCount = (itemCount) =>
+	Math.min(Math.max(itemCount || 0, 0), INITIAL_CARD_WINDOW);
+
+export const expandedCardCount = (currentCount, focusedIndex, itemCount) => {
+	const total = Math.max(itemCount || 0, 0);
+	const current = Math.min(Math.max(currentCount || 0, 0), total);
+	if (focusedIndex < current - CARD_WINDOW_EDGE) return current;
+	return Math.min(total, current + CARD_WINDOW_STEP);
+};
+
+export const searchArtworkOptions = (aspect, tag) => {
+	const size = aspect === 'poster' ? {maxHeight: 360} : {maxWidth: 440};
+	return tag ? {...size, quality: 75, tag} : {...size, quality: 75};
+};

--- a/packages/app/src/views/Search/searchWindow.test.js
+++ b/packages/app/src/views/Search/searchWindow.test.js
@@ -21,13 +21,15 @@ describe('search result windowing', () => {
 		expect(expandedCardCount(18, 17, 24)).toBe(24);
 	});
 
+	// The same sizes and quality the rest of the app asks for, so search reads
+	// the images the server already rendered.
 	test('sizes artwork for its card shape', () => {
 		expect(searchArtworkOptions('poster', 'poster-tag')).toEqual({
-			maxHeight: 360,
-			quality: 75,
+			maxHeight: 300,
+			quality: 80,
 			tag: 'poster-tag'
 		});
-		expect(searchArtworkOptions('wide')).toEqual({maxWidth: 440, quality: 75});
-		expect(searchArtworkOptions('square')).toEqual({maxWidth: 440, quality: 75});
+		expect(searchArtworkOptions('wide')).toEqual({maxWidth: 400, quality: 80});
+		expect(searchArtworkOptions('square')).toEqual({maxWidth: 400, quality: 80});
 	});
 });

--- a/packages/app/src/views/Search/searchWindow.test.js
+++ b/packages/app/src/views/Search/searchWindow.test.js
@@ -1,0 +1,33 @@
+import {
+	initialCardCount,
+	expandedCardCount,
+	searchArtworkOptions,
+	shouldMountSearchRow
+} from './searchWindow';
+
+describe('search result windowing', () => {
+	test('mounts only the active row and its immediate neighbours', () => {
+		expect(shouldMountSearchRow(0, 0)).toBe(true);
+		expect(shouldMountSearchRow(1, 0)).toBe(true);
+		expect(shouldMountSearchRow(2, 0)).toBe(false);
+		expect(shouldMountSearchRow(2, 3)).toBe(true);
+	});
+
+	test('starts with one screen of cards and expands near the edge', () => {
+		expect(initialCardCount(24)).toBe(10);
+		expect(initialCardCount(6)).toBe(6);
+		expect(expandedCardCount(10, 3, 24)).toBe(10);
+		expect(expandedCardCount(10, 8, 24)).toBe(18);
+		expect(expandedCardCount(18, 17, 24)).toBe(24);
+	});
+
+	test('sizes artwork for its card shape', () => {
+		expect(searchArtworkOptions('poster', 'poster-tag')).toEqual({
+			maxHeight: 360,
+			quality: 75,
+			tag: 'poster-tag'
+		});
+		expect(searchArtworkOptions('wide')).toEqual({maxWidth: 440, quality: 75});
+		expect(searchArtworkOptions('square')).toEqual({maxWidth: 440, quality: 75});
+	});
+});


### PR DESCRIPTION
# Pull Request

## Summary
Improves live search responsiveness by limiting how many result cards are rendered at once and requesting artwork sized appropriately for TV cards. All search results remain accessible as the user navigates.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Render only the active result row and its immediate neighbors.
- Initially render 10 cards per row and progressively load more as the user navigates.
- Request appropriately sized and compressed Jellyfin artwork.
- Add unit tests for result windowing and artwork sizing.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Tested on physical LG webOS and Samsung Tizen TVs. Both showed substantially improved keyboard responsiveness and a smoother live search experience.

### Test Steps
1. Enter several search queries using the on-screen keyboard.
2. Verify the keyboard remains responsive while live results update.
3. Navigate through result rows and confirm additional cards appear normally.
4. Verify artwork, focus navigation, and item selection continue to work.

## Screenshots (if applicable)
N/A — performance and interaction change.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced