### PR TITLE
harden: sanitize child_process call in build-all.js...

### DIFF
--- a/packages/build-tizen/scripts/build-all.js
+++ b/packages/build-tizen/scripts/build-all.js
@@ -52,7 +52,7 @@ function build(label, extraFlags) {
 	console.log('\n' + cyan('═'.repeat(50)));
 	console.log(cyan(`  Building: ${label}`));
 	console.log(cyan('═'.repeat(50)) + '\n');
-	execSync(`node "${SCRIPT}" ${allArgs.join(' ')}`, {stdio: 'inherit', cwd: ROOT});
+	spawnSync('node', [SCRIPT, ...allArgs], {stdio: 'inherit', cwd: ROOT});
 }
 
 build('Regular', []);


### PR DESCRIPTION
## Summary
Harden input handling in `packages/build-tizen/scripts/build-all.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `packages/build-tizen/scripts/build-all.js:55` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `extraFlags`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `packages/build-tizen/scripts/build-all.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
