### PR TITLE
fix(search): improve focus navigation and row scrolling

### DIFF
--- a/packages/app/src/components/DetailsTabBar/DetailsTabBar.js
+++ b/packages/app/src/components/DetailsTabBar/DetailsTabBar.js
@@ -11,7 +11,7 @@ const TabContainer = SpotlightContainerDecorator({restrict: 'self-first'}, 'div'
 
 // A d-pad focusable pill tab bar. The pill highlight and focus states are all in
 // CSS, so navigating left and right only moves focus and reports the active id.
-const DetailsTabBar = ({tabs, activeId, onSelect, onActivate, expanded = true, spotlightId, className}) => {
+const DetailsTabBar = ({tabs, activeId, activeSpotlightId, onSelect, onActivate, expanded = true, spotlightId, className}) => {
 	const handleClick = useCallback((ev) => {
 		const id = ev.currentTarget.dataset.id;
 		if (id) onActivate?.(id);
@@ -33,6 +33,7 @@ const DetailsTabBar = ({tabs, activeId, onSelect, onActivate, expanded = true, s
 			{tabs.map((tab) => (
 				<Pill
 					key={tab.id}
+					spotlightId={tab.id === activeId ? activeSpotlightId : undefined}
 					data-id={tab.id}
 					className={`${css.tab} ${tab.id === activeId ? css.tabActive : ''}`}
 					onClick={handleClick}

--- a/packages/app/src/components/Sidebar/Sidebar.module.less
+++ b/packages/app/src/components/Sidebar/Sidebar.module.less
@@ -1,6 +1,6 @@
+@import '../../styles/variables.less';
+
 @accent: var(--accent-color, #00a4dc);
-@sidebar-collapsed-width: 78px;
-@sidebar-expanded-width: 280px;
 
 .sidebar {
 	position: fixed;

--- a/packages/app/src/styles/variables.less
+++ b/packages/app/src/styles/variables.less
@@ -13,3 +13,6 @@
 @border-color: var(--theme-border-color, #333333);
 
 @gradient-primary: linear-gradient(180deg, transparent 0%, var(--theme-background, #101010) 100%);
+
+@sidebar-collapsed-width: 78px;
+@sidebar-expanded-width: 280px;

--- a/packages/app/src/theme/themeOverrides.js
+++ b/packages/app/src/theme/themeOverrides.js
@@ -27,6 +27,7 @@ import appCss from '../App/App.module.less';
 import sidebarCss from '../components/Sidebar/Sidebar.module.less';
 import navBarCss from '../components/NavBar/NavBar.module.less';
 import settingsCss from '../views/Settings/Settings.module.less';
+import searchCss from '../views/Search/Search.module.less';
 import detailsCss from '../views/Details/Details.module.less';
 import modernDetailCss from '../views/Details/ModernDetailContent.module.less';
 import overviewCss from '../views/Details/ExpandableOverview.module.less';
@@ -217,6 +218,10 @@ export const buildThemeOverrideCss = (theme, options = {}) => {
 	rule(`.${settingsCss.playbackTimeBar}`, `background: ${rangeTrack};`);
 	rule(`.${settingsCss.playbackTimeBarFill}`, `background: ${rangeProgress};`);
 
+	// Search input
+	rule(`.${searchCss.searchInputWrapper}`, `background: ${inputBackground}; border-color: ${inputBorder};`);
+	rule(`.${searchCss.searchInputFocused}`, `background: ${inputFocused}; border-color: ${focusColor}; box-shadow: ${glowOr('none')};`);
+
 	// Detail screens, classic layout
 	rule(`.${detailsCss.posterBadgeWatched}, .${detailsCss.watchedIndicator}`, `background: ${badgeWatched};`);
 	rule(`.${detailsCss.posterBadgeWatched} svg, .${detailsCss.watchedIndicator} svg`, `fill: ${onBadge};`);
@@ -373,7 +378,7 @@ export const buildThemeOverrideCss = (theme, options = {}) => {
 			`.${navBarCss.navPill}`, `.${navBarCss.navBtn}`,
 			`.${settingsCss.listItem}`, `.${settingsCss.listItemIcon}`, `.${settingsCss.sliderContainer}`,
 			`.${settingsCss.themeCard}`, `.${settingsCss.themeCardStripe}`, `.${settingsCss.input}`,
-			`.${settingsCss.searchInput}`, `.${settingsCss.actionButton}`, `.${settingsCss.playbackTimePreview}`,
+			`.${settingsCss.searchInput}`, `.${settingsCss.actionButton}`, `.${settingsCss.playbackTimePreview}`, `.${searchCss.searchInputWrapper}`,
 			`.${detailsCss.poster}`, `.${detailsCss.btnAction}`, `.${detailsCss.nextUpCard}`,
 			`.${detailsCss.episodeCard}`, `.${detailsCss.chapterCard}`, `.${detailsCss.extraCard}`,
 			`.${detailsCss.seasonPosterWrapper}`, `.${detailsCss.episodeNumber}`, `.${detailsCss.badge}`,

--- a/packages/app/src/views/Search/Search.js
+++ b/packages/app/src/views/Search/Search.js
@@ -31,8 +31,10 @@ import css from './Search.module.less';
 
 const SpottableDiv = Spottable('div');
 const SpottableButton = Spottable('button');
+const ACTIVE_SEARCH_TAB_ID = 'search-active-tab';
+const ACTIVE_SEARCH_TAB_SELECTOR = `[data-spotlight-id="${ACTIVE_SEARCH_TAB_ID}"]`;
 const RowContainer = SpotlightContainerDecorator({enterTo: 'last-focused', restrict: 'self-first'}, 'div');
-const GridContainer = SpotlightContainerDecorator({enterTo: 'last-focused', leaveFor: {up: 'search-tabs'}}, 'div');
+const GridContainer = SpotlightContainerDecorator({enterTo: 'last-focused', leaveFor: {up: ACTIVE_SEARCH_TAB_SELECTOR}}, 'div');
 // Without a default element, entering the container lands on Clear, since that
 // is first in the DOM. Point it at the chips so arriving here offers a search.
 const RecentContainer = SpotlightContainerDecorator({
@@ -46,6 +48,7 @@ const GLOBAL_FETCH_LIMIT = 240;
 const SEERR_CAP = 24;
 const RECENT_SEARCHES_KEY = 'search_recentQueries';
 const RECENT_SEARCHES_MAX = 10;
+const ROW_SCROLL_MARGIN = 50;
 
 const SearchIcon = () => (
 	<svg viewBox="0 0 24 24" fill="currentColor" className={css.searchIcon}>
@@ -96,6 +99,7 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 	const [seerrResults, setSeerrResults] = useState([]);
 	const [gameResults, setGameResults] = useState([]);
 	const [activeTab, setActiveTab] = useState('all');
+	const [searchInputFocused, setSearchInputFocused] = useState(false);
 	const [activeRowIndex, setActiveRowIndex] = useState(0);
 	const [visibleCardCounts, setVisibleCardCounts] = useState({});
 	const [recentSearches, saveRecentSearches] = useStorage(RECENT_SEARCHES_KEY, []);
@@ -330,6 +334,11 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 		if (focusBelowInput()) e.preventDefault();
 	}, [focusBelowInput]);
 
+	const handleSearchInputFocus = useCallback(() => setSearchInputFocused(true), []);
+	const handleSearchInputBlur = useCallback((e) => {
+		if (!e.currentTarget.contains(e.relatedTarget)) setSearchInputFocused(false);
+	}, []);
+
 	const focusContent = useCallback(() => {
 		if (activeTab === 'all') setActiveRowIndex(0);
 		Spotlight.focus(activeTab === 'all' ? 'search-row-0' : 'search-grid');
@@ -356,7 +365,7 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 			e.preventDefault();
 			e.stopPropagation();
 			if (rowIndex === 0) {
-				Spotlight.focus('search-tabs');
+				Spotlight.focus(ACTIVE_SEARCH_TAB_SELECTOR);
 			} else {
 				setActiveRowIndex(rowIndex - 1);
 				Spotlight.focus(`search-row-${rowIndex - 1}`);
@@ -387,13 +396,17 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 				return expanded === visible ? current : {...current, [rowId]: expanded};
 			});
 		}
-		const cardRect = card.getBoundingClientRect();
-		const scrollerRect = scroller.getBoundingClientRect();
-		if (cardRect.left < scrollerRect.left) {
-			scroller.scrollLeft -= (scrollerRect.left - cardRect.left + 50);
-		} else if (cardRect.right > scrollerRect.right) {
-			scroller.scrollLeft += (cardRect.right - scrollerRect.right + 50);
-		}
+		window.requestAnimationFrame(() => {
+			const cardRect = card.getBoundingClientRect();
+			const scrollerRect = scroller.getBoundingClientRect();
+			const leftEdge = scrollerRect.left + ROW_SCROLL_MARGIN;
+			const rightEdge = scrollerRect.right - ROW_SCROLL_MARGIN;
+			if (cardRect.left < leftEdge) {
+				scroller.scrollLeft -= leftEdge - cardRect.left;
+			} else if (cardRect.right > rightEdge) {
+				scroller.scrollLeft += cardRect.right - rightEdge;
+			}
+		});
 	}, []);
 
 	const handleSelectJellyfin = useCallback((item) => {
@@ -571,9 +584,13 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 	};
 
 	return (
-		<div className={css.searchContainer}>
+		<div className={`${css.searchContainer} ${settings.navbarPosition === 'left' ? css.sidebarOffset : ''}`}>
 			<div className={css.searchInputSection}>
-				<div className={css.searchInputWrapper}>
+				<div
+					className={`${css.searchInputWrapper} ${searchInputFocused ? css.searchInputFocused : ''}`}
+					onFocusCapture={handleSearchInputFocus}
+					onBlurCapture={handleSearchInputBlur}
+				>
 					<SearchIcon />
 					<SpottableInput
 						type="text"
@@ -599,6 +616,7 @@ const Search = ({onSelectItem, onSelectSeerrItem, onSelectPerson, onSelectGame, 
 						<DetailsTabBar
 							tabs={tabs}
 							activeId={activeTab}
+							activeSpotlightId={ACTIVE_SEARCH_TAB_ID}
 							onSelect={handleSelectTab}
 							onActivate={handleSelectTab}
 							expanded

--- a/packages/app/src/views/Search/Search.module.less
+++ b/packages/app/src/views/Search/Search.module.less
@@ -1,4 +1,5 @@
 @import '../../styles/mixins.less';
+@import '../../styles/variables.less';
 
 /* Search Container */
 .searchContainer {
@@ -13,8 +14,9 @@
 	padding-top: 80px;
 }
 
+// The collapsed sidebar sits over the page, so the results start clear of it.
 .sidebarOffset {
-	padding-left: 78px;
+	padding-left: @sidebar-collapsed-width;
 	box-sizing: border-box;
 }
 
@@ -230,7 +232,6 @@
 
 .rowScroller {
 	overflow-x: auto;
-	overflow-y: visible;
 	position: relative;
 	padding: 0 60px;
 	margin-left: -60px;

--- a/packages/app/src/views/Search/Search.module.less
+++ b/packages/app/src/views/Search/Search.module.less
@@ -13,6 +13,11 @@
 	padding-top: 80px;
 }
 
+.sidebarOffset {
+	padding-left: 78px;
+	box-sizing: border-box;
+}
+
 /* Search Input Section */
 .searchInputSection {
 	padding: 60px 0 30px;
@@ -36,12 +41,12 @@
 	padding: 10px 24px;
 	transition: all 0.3s ease;
 	height: 50px;
+}
 
-	&:focus-within {
-		border-color: var(--theme-focus-border-color, #ffffff);
-		background: var(--theme-input-focused, rgba(255, 255, 255, 0.15));
-		box-shadow: var(--theme-focus-glow, 0 0 20px rgba(0, 164, 220, 0.3));
-	}
+.searchInputFocused {
+	border-color: var(--theme-focus-border-color, #ffffff);
+	background: var(--theme-input-focused, rgba(255, 255, 255, 0.15));
+	box-shadow: var(--theme-focus-glow, 0 0 20px rgba(0, 164, 220, 0.3));
 }
 
 .searchIcon {
@@ -224,20 +229,26 @@
 }
 
 .rowScroller {
-	overflow: visible;
-	position: relative;
-}
-
-.resultItems {
-	display: flex;
 	overflow-x: auto;
 	overflow-y: visible;
+	position: relative;
+	padding: 0 60px;
+	margin-left: -60px;
+	margin-right: -60px;
 	scroll-behavior: smooth;
-	padding: 30px 0 30px 8px;
+	scrollbar-width: none;
 
 	&::-webkit-scrollbar {
 		display: none;
 	}
+}
+
+.resultItems {
+	display: -webkit-flex;
+	display: flex;
+	padding: 30px 0 30px 8px;
+	width: -webkit-max-content;
+	width: max-content;
 }
 
 /* Grid tab */


### PR DESCRIPTION
# Pull Request

## Summary
Improves remote navigation and layout behavior in Search. The selected category is restored when leaving results, the search field shows its themed focus state, the collapsed left navigation no longer overlaps content, and the final result card scrolls fully onscreen.

## Related Issues
None.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Return upward navigation to the currently selected search category.
- Add theme-aware search-field focus styling and collapsed-sidebar spacing.
- Correct result-row scrolling and provide sufficient edge space for focused cards.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [x] Both / Shared code

## Testing
- [ ] Tested on emulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Tested on an LG webOS TV.

### Test Steps
1. Search for a term with results across multiple categories.
2. Navigate between the search field, category tabs, and result rows.
3. Navigate to the final item in a full result row and confirm the focused card remains fully visible.

## Screenshots (if applicable)
N/A.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced