### PR TITLE
Markers for SmartTV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -716,7 +716,7 @@
 		},
 		"packages/app": {
 			"name": "@moonfin/app",
-			"version": "2.8.0",
+			"version": "2.8.2",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@enact/core": "^4.8.0",
@@ -745,11 +745,11 @@
 		},
 		"packages/build-tizen": {
 			"name": "@moonfin/build-tizen",
-			"version": "2.8.0"
+			"version": "2.8.2"
 		},
 		"packages/build-webos": {
 			"name": "@moonfin/build-webos",
-			"version": "2.8.0"
+			"version": "2.8.2"
 		},
 		"packages/cli-shim": {
 			"name": "@moonfin/cli-shim",
@@ -764,11 +764,11 @@
 		},
 		"packages/platform-tizen": {
 			"name": "@moonfin/platform-tizen",
-			"version": "2.8.0"
+			"version": "2.8.2"
 		},
 		"packages/platform-webos": {
 			"name": "@moonfin/platform-webos",
-			"version": "2.8.0"
+			"version": "2.8.2"
 		}
 	}
 }

--- a/packages/app/src/components/AnimeMarkerPills/AnimeMarkerPills.js
+++ b/packages/app/src/components/AnimeMarkerPills/AnimeMarkerPills.js
@@ -1,0 +1,51 @@
+import $L from '@enact/i18n/$L';
+
+import css from './AnimeMarkerPills.module.less';
+
+// AnimeEpisodeKind.
+const KIND_PILLS = {
+	Filler: {label: 'Filler', tone: css.filler},
+	Mixed: {label: 'Mixed Canon/Filler', tone: css.mixed},
+	MangaCanon: {label: 'Manga Canon', tone: css.mangaCanon},
+	AnimeCanon: {label: 'Anime Canon', tone: css.animeCanon}
+};
+
+// AnimeAudioKind
+const AUDIO_PILLS = {
+	Subbed: {label: 'Subbed', tone: css.subbed},
+	Dubbed: {label: 'Dubbed', tone: css.dubbed},
+	SubbedAndDubbed: {label: 'Subbed/Dubbed', tone: css.dual}
+};
+
+// Whether there is anything to show for the given marker and audio.
+export const hasAnimeMarkerPills = (marker, audio) => Boolean(
+	(marker?.kind && KIND_PILLS[marker.kind]) ||
+	marker?.recap === true ||
+	AUDIO_PILLS[audio || marker?.audio]
+);
+
+// The pills for one episode, season or movie.
+const AnimeMarkerPills = ({marker, audio, compact, large, max, className = ''}) => {
+	const kind = marker?.kind ? KIND_PILLS[marker.kind] : null;
+	const recap = marker?.recap === true;
+	const audioKind = audio || marker?.audio;
+	const audioPill = audioKind ? AUDIO_PILLS[audioKind] : null;
+	const pills = [];
+	if (kind) pills.push({key: 'kind', label: kind.label, tone: kind.tone});
+	if (recap) pills.push({key: 'recap', label: 'Recap', tone: css.recap});
+	if (audioPill) pills.push({key: 'audio', label: audioPill.label, tone: audioPill.tone});
+
+	const shown = max > 0 ? pills.slice(0, max) : pills;
+	if (shown.length === 0) return null;
+
+	const size = compact ? css.compact : (large ? css.large : '');
+	const rowClass = `${css.row} ${size} ${className}`.trim();
+
+	return (
+		<span className={rowClass}>
+			{shown.map(p => <span key={p.key} className={`${css.pill} ${p.tone}`}>{$L(p.label)}</span>)}
+		</span>
+	);
+};
+
+export default AnimeMarkerPills;

--- a/packages/app/src/components/AnimeMarkerPills/AnimeMarkerPills.module.less
+++ b/packages/app/src/components/AnimeMarkerPills/AnimeMarkerPills.module.less
@@ -1,0 +1,102 @@
+.row {
+	display: inline-flex;
+	flex-direction: row;
+	align-items: center;
+	flex-wrap: wrap;
+
+	> * + * {
+		margin-left: 8px;
+	}
+}
+
+.pill {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 11px;
+	border-radius: 9px;
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 1.5;
+	letter-spacing: 0.2px;
+	white-space: nowrap;
+
+	border-width: 1px;
+	border-style: solid;
+}
+
+.compact .pill {
+	padding: 1px 9px;
+	border-radius: 8px;
+	font-size: 13px;
+}
+
+.large .pill {
+	padding: 3px 14px;
+	border-radius: 11px;
+	font-size: 19px;
+}
+
+.filler {
+	color: #ffc48a;
+	background: rgba(255, 138, 0, 0.18);
+	border-color: rgba(255, 138, 0, 0.55);
+}
+
+.mixed {
+	color: #ffe08a;
+	background: rgba(255, 193, 7, 0.16);
+	border-color: rgba(255, 193, 7, 0.5);
+}
+
+.mangaCanon {
+	color: #9ce8b4;
+	background: rgba(46, 204, 113, 0.16);
+	border-color: rgba(46, 204, 113, 0.5);
+}
+
+.animeCanon {
+	color: #9ecbff;
+	background: rgba(52, 152, 219, 0.18);
+	border-color: rgba(52, 152, 219, 0.55);
+}
+
+.recap {
+	color: #d3b4ff;
+	background: rgba(155, 89, 232, 0.18);
+	border-color: rgba(155, 89, 232, 0.55);
+}
+
+.subbed {
+	color: #a9d8ff;
+	background: rgba(0, 164, 220, 0.18);
+	border-color: rgba(0, 164, 220, 0.55);
+}
+
+.dubbed {
+	color: #ffb3b3;
+	background: rgba(231, 76, 60, 0.18);
+	border-color: rgba(231, 76, 60, 0.55);
+}
+
+.dual {
+	color: #c4c9ff;
+	background: rgba(120, 120, 255, 0.18);
+	border-color: rgba(120, 120, 255, 0.55);
+}
+
+.cardOverlay {
+	position: absolute;
+	left: 8px;
+	bottom: 8px;
+	z-index: 2;
+	max-width: ~'calc(100% - 16px)';
+
+	.pill {
+		background-color: rgba(0, 0, 0, 0.72);
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+	}
+}
+
+.aboveProgress {
+	bottom: 26px;
+}

--- a/packages/app/src/components/AnimeMarkerPills/AnimeMarkerPillsFor.js
+++ b/packages/app/src/components/AnimeMarkerPills/AnimeMarkerPillsFor.js
@@ -1,0 +1,39 @@
+import AnimeMarkerPills from './AnimeMarkerPills';
+import {useEpisodeMarker, useItemAudio} from './useAnimeMarkers';
+
+import css from './AnimeMarkerPills.module.less';
+
+// How long a card waits before asking. So that the cards load in first bevor the pills come.
+const CARD_DELAY_MS = 700;
+
+// The pills for one episode, fetching what it needs itself.
+export const AnimeEpisodePills = ({episode, serverUrl, compact, large, className}) => {
+	const marker = useEpisodeMarker(episode, {serverUrl});
+	return <AnimeMarkerPills marker={marker} compact={compact} large={large} className={className} />;
+};
+
+// The pills for whatever a detail screen is showing.
+export const AnimeItemPills = ({item, serverUrl, compact, large, className}) => {
+	const isEpisode = item?.Type === 'Episode';
+	const marker = useEpisodeMarker(isEpisode ? item : null, {serverUrl});
+	const audio = useItemAudio(item?.Type === 'Movie' ? item : null, {serverUrl});
+
+	return <AnimeMarkerPills marker={marker} audio={audio} compact={compact} large={large} className={className} />;
+};
+
+// The pill drawn over a home row card's artwork.
+export const AnimeCardPill = ({item, serverUrl, hasProgressBar}) => {
+	const isEpisode = item?.Type === 'Episode';
+	const marker = useEpisodeMarker(isEpisode ? item : null, {serverUrl, delayMs: CARD_DELAY_MS});
+	const audio = useItemAudio(item?.Type === 'Movie' ? item : null, {serverUrl, delayMs: CARD_DELAY_MS});
+
+	return (
+		<AnimeMarkerPills
+			marker={marker}
+			audio={audio}
+			compact
+			max={1}
+			className={`${css.cardOverlay} ${hasProgressBar ? css.aboveProgress : ''}`}
+		/>
+	);
+};

--- a/packages/app/src/components/AnimeMarkerPills/index.js
+++ b/packages/app/src/components/AnimeMarkerPills/index.js
@@ -1,0 +1,4 @@
+export {default} from './AnimeMarkerPills';
+export {default as AnimeMarkerPills, hasAnimeMarkerPills} from './AnimeMarkerPills';
+export {AnimeEpisodePills, AnimeItemPills, AnimeCardPill} from './AnimeMarkerPillsFor';
+export {useAnimeMarkers, useEpisodeMarker, useItemAudio, markerForEpisode, audioForSeason} from './useAnimeMarkers';

--- a/packages/app/src/components/AnimeMarkerPills/useAnimeMarkers.js
+++ b/packages/app/src/components/AnimeMarkerPills/useAnimeMarkers.js
@@ -1,0 +1,89 @@
+import {useState, useEffect} from 'react';
+
+import {useSettings} from '../../context/SettingsContext';
+import {
+	fetchSeriesMarkers,
+	fetchItemMarkers,
+	audioForItem,
+	markerForEpisode,
+	audioForSeason,
+	areAnimeMarkersEnabled
+} from '../../services/animeMarkersApi';
+
+// Every marker for one series, keyed by episode and season id.
+
+export const useAnimeMarkers = (seriesId, {serverUrl, delayMs = 0} = {}) => {
+	const {settings} = useSettings();
+	const enabled = areAnimeMarkersEnabled(settings);
+	const [markers, setMarkers] = useState(null);
+
+	useEffect(() => {
+		if (!enabled || !seriesId) {
+			setMarkers(null);
+			return undefined;
+		}
+
+		let cancelled = false;
+		const ask = () => {
+			fetchSeriesMarkers(seriesId, {serverUrl}).then(result => {
+				if (!cancelled) setMarkers(result);
+			});
+		};
+
+		if (delayMs > 0) {
+			const timer = setTimeout(ask, delayMs);
+			return () => {
+				cancelled = true;
+				clearTimeout(timer);
+			};
+		}
+
+		ask();
+		return () => { cancelled = true; };
+	}, [enabled, seriesId, serverUrl, delayMs]);
+
+	return markers;
+};
+
+
+export const useEpisodeMarker = (episode, {serverUrl, delayMs} = {}) => {
+	const markers = useAnimeMarkers(episode?.SeriesId, {serverUrl, delayMs});
+	return markerForEpisode(markers, episode?.Id);
+};
+
+// The subbed/dubbed verdict for a standalone item, which in practice means a movie.
+export const useItemAudio = (item, {serverUrl, delayMs = 0} = {}) => {
+	const {settings} = useSettings();
+	const enabled = areAnimeMarkersEnabled(settings);
+	const itemId = item?.Id;
+	const [audio, setAudio] = useState(null);
+
+	useEffect(() => {
+		if (!enabled || !itemId) {
+			setAudio(null);
+			return undefined;
+		}
+
+		let cancelled = false;
+		const ask = () => {
+			fetchItemMarkers([itemId], {serverUrl}).then(() => {
+				if (!cancelled) setAudio(audioForItem(itemId));
+			});
+		};
+
+		if (delayMs > 0) {
+			const timer = setTimeout(ask, delayMs);
+			return () => {
+				cancelled = true;
+				clearTimeout(timer);
+			};
+		}
+
+		ask();
+		return () => { cancelled = true; };
+	}, [enabled, itemId, serverUrl, delayMs]);
+
+	return audio;
+};
+
+export {markerForEpisode, audioForSeason};

--- a/packages/app/src/components/MediaCard/MediaCard.js
+++ b/packages/app/src/components/MediaCard/MediaCard.js
@@ -3,6 +3,7 @@ import Spottable from '@enact/spotlight/Spottable';
 import {getImageUrl} from '../../utils/helpers';
 import {useSettings} from '../../context/SettingsContext';
 import {SeerrSeasonDot} from '../seerr/SeerrStatusBadge';
+import {AnimeCardPill} from '../AnimeMarkerPills';
 
 import css from './MediaCard.module.less';
 
@@ -310,6 +311,8 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', rowImageType = 'post
 						<svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
 					</div>
 				)}
+
+				<AnimeCardPill item={item} serverUrl={itemServerUrl} hasProgressBar={showIndicators && progress > 0} />
 			</div>
 
 			<div className={css.info}>

--- a/packages/app/src/components/MediaCard/ModernMediaCard.js
+++ b/packages/app/src/components/MediaCard/ModernMediaCard.js
@@ -7,6 +7,7 @@ import {getImageUrl} from '../../utils/helpers';
 import {useSettings} from '../../context/SettingsContext';
 import {getPlatform} from '../../platform';
 import {isStaticLibraryCard, modernCardMetrics} from './modernCardLayout';
+import {AnimeCardPill} from '../AnimeMarkerPills';
 
 import css from './ModernMediaCard.module.less';
 
@@ -363,6 +364,8 @@ const ModernMediaCard = ({
 						<svg viewBox="0 0 24 24"><path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
 					</div>
 				)}
+
+				<AnimeCardPill item={item} serverUrl={itemServerUrl} hasProgressBar={showIndicators && progress > 0} />
 			</div>
 
 			<div className={css.title}>{displayTitle}</div>

--- a/packages/app/src/services/animeMarkersApi.js
+++ b/packages/app/src/services/animeMarkersApi.js
@@ -1,0 +1,226 @@
+import {getAuthHeader, getServerUrl} from './jellyfinApi';
+import {mediaServerQueue} from '../utils/requestQueue';
+
+const seriesCache = {};
+const CACHE_TTL_MS = 30 * 60 * 1000;
+
+const negativeCache = {};
+const NEGATIVE_CACHE_TTL_MS = 3 * 60 * 1000;
+
+const pendingSeries = {};
+
+const itemAudio = {};
+const itemAsked = {};
+
+let placement = 'below';
+
+export const MARKER_PLACEMENT = {
+	below: 'below',
+	beside: 'beside',
+	thumbnail: 'thumbnail'
+};
+
+export const getMarkerPlacement = () => placement;
+
+const rememberPlacement = (value) => {
+	if (value === 'beside' || value === 'thumbnail' || value === 'below') {
+		placement = value;
+	}
+};
+
+const normalizeId = (id) => String(id || '').replace(/-/g, '').toLowerCase();
+
+const isNegativelyCached = (key) => {
+	const at = negativeCache[key];
+	if (!at) return false;
+	if ((Date.now() - at) < NEGATIVE_CACHE_TTL_MS) return true;
+	delete negativeCache[key];
+	return false;
+};
+
+export const areAnimeMarkersEnabled = (settings) => !!settings?.useMoonfinPlugin;
+
+const request = async (url, signal) => {
+	const options = {headers: {'Authorization': getAuthHeader()}};
+	if (signal) options.signal = signal;
+
+	return mediaServerQueue.run(() => fetch(url, options));
+};
+
+// Markers for every episode of one series, key is the episode id.
+export const fetchSeriesMarkers = async (seriesId, options = {}) => {
+	const key = normalizeId(seriesId);
+	if (!key) return null;
+
+	const cached = seriesCache[key];
+	if (cached && (Date.now() - cached.fetchedAt) < CACHE_TTL_MS) {
+		return cached.data;
+	}
+	if (isNegativelyCached(key)) return null;
+	if (pendingSeries[key]) return pendingSeries[key];
+
+	const baseUrl = options.serverUrl || getServerUrl();
+	if (!baseUrl) return null;
+
+	const run = (async () => {
+		try {
+			const url = `${baseUrl}/Moonfin/AnimeMarkers/Series?seriesId=${encodeURIComponent(seriesId)}`;
+			const response = await request(url, options.signal);
+
+			if (!response.ok) {
+				negativeCache[key] = Date.now();
+				return null;
+			}
+
+			const body = await response.json();
+			rememberPlacement(body?.placement);
+
+			if (body?.enabled !== true) {
+				const empty = {episodes: {}, seasons: {}};
+				seriesCache[key] = {fetchedAt: Date.now(), data: empty};
+				return empty;
+			}
+
+			if (body?.pending === true) {
+				negativeCache[key] = Date.now();
+				return null;
+			}
+
+			const episodes = {};
+			const rawEpisodes = body?.episodes || {};
+			Object.keys(rawEpisodes).forEach(id => {
+				const entry = rawEpisodes[id];
+				if (!entry) return;
+				episodes[normalizeId(id)] = {
+					kind: entry.kind || null,
+					recap: entry.recap === true,
+					audio: entry.audio || null
+				};
+			});
+
+			const seasons = {};
+			const rawSeasons = body?.seasons || {};
+			Object.keys(rawSeasons).forEach(id => {
+				const entry = rawSeasons[id];
+				if (entry?.audio) seasons[normalizeId(id)] = entry.audio;
+			});
+
+			const data = {episodes, seasons};
+			seriesCache[key] = {fetchedAt: Date.now(), data};
+			return data;
+		} catch (e) {
+			if (e?.name !== 'AbortError') negativeCache[key] = Date.now();
+			return null;
+		} finally {
+			delete pendingSeries[key];
+		}
+	})();
+
+	pendingSeries[key] = run;
+	return run;
+};
+
+export const markerForEpisode = (markers, episodeId) => {
+	if (!markers?.episodes) return null;
+	return markers.episodes[normalizeId(episodeId)] || null;
+};
+
+export const audioForSeason = (markers, seasonId) => {
+	if (!markers?.seasons) return null;
+	return markers.seasons[normalizeId(seasonId)] || null;
+};
+
+// Ids waiting to go out, the callers waiting on them, and when a lookup last failed.
+const itemQueue = new Set();
+const itemWaiters = [];
+const itemFailedAt = {};
+let itemTimer = null;
+let itemBaseUrl = null;
+
+// Long enough for a row of cards to finish loading.
+const ITEM_BATCH_MS = 80;
+
+// The plugin ignores anything past 200 ids in one request.
+const ITEM_BATCH_MAX = 200;
+
+const flushItemBatch = async () => {
+	const ids = Array.from(itemQueue).slice(0, ITEM_BATCH_MAX);
+	ids.forEach(id => itemQueue.delete(id));
+
+	const waiters = itemWaiters.splice(0, itemWaiters.length);
+	const baseUrl = itemBaseUrl || getServerUrl();
+
+	try {
+		if (ids.length === 0 || !baseUrl) return;
+
+		const url = `${baseUrl}/Moonfin/AnimeMarkers/Items?ids=${encodeURIComponent(ids.join(','))}`;
+		const response = await request(url);
+		if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+		const body = await response.json();
+		rememberPlacement(body?.placement);
+
+		const items = body?.items || {};
+		Object.keys(items).forEach(id => {
+			const audio = items[id]?.audio;
+			if (audio) itemAudio[normalizeId(id)] = audio;
+		});
+
+		ids.forEach(id => {
+			itemAsked[id] = true;
+			delete itemFailedAt[id];
+		});
+	} catch (e) {
+		const now = Date.now();
+		ids.forEach(id => {
+			itemFailedAt[id] = now;
+		});
+	} finally {
+		waiters.forEach(resolve => resolve());
+
+		if (itemQueue.size > 0 && !itemTimer) {
+			itemTimer = setTimeout(() => {
+				itemTimer = null;
+				flushItemBatch();
+			}, ITEM_BATCH_MS);
+		}
+	}
+};
+
+export const fetchItemMarkers = async (itemIds, options = {}) => {
+	const wanted = (itemIds || [])
+		.map(normalizeId)
+		.filter(id => id && !(id in itemAsked))
+		.filter(id => {
+			const failedAt = itemFailedAt[id];
+			return !failedAt || (Date.now() - failedAt) >= NEGATIVE_CACHE_TTL_MS;
+		});
+
+	if (wanted.length === 0) return itemAudio;
+
+	wanted.forEach(id => itemQueue.add(id));
+	itemBaseUrl = options.serverUrl || itemBaseUrl;
+
+	await new Promise(resolve => {
+		itemWaiters.push(resolve);
+		if (!itemTimer) {
+			itemTimer = setTimeout(() => {
+				itemTimer = null;
+				flushItemBatch();
+			}, ITEM_BATCH_MS);
+		}
+	});
+
+	return itemAudio;
+};
+
+export const audioForItem = (itemId) => itemAudio[normalizeId(itemId)] || null;
+
+export const clearAnimeMarkerCache = () => {
+	Object.keys(seriesCache).forEach(k => delete seriesCache[k]);
+	Object.keys(negativeCache).forEach(k => delete negativeCache[k]);
+	Object.keys(itemAudio).forEach(k => delete itemAudio[k]);
+	Object.keys(itemAsked).forEach(k => delete itemAsked[k]);
+	Object.keys(itemFailedAt).forEach(k => delete itemFailedAt[k]);
+	placement = 'below';
+};

--- a/packages/app/src/views/Details/ClassicDetailScreen.js
+++ b/packages/app/src/views/Details/ClassicDetailScreen.js
@@ -16,6 +16,7 @@ import {handleSectionKeyDown, handleScrollerFocus} from './detailsFocus';
 import {PosterBadges, WatchedCheckIcon, FavoriteHeartIcon} from './DetailBadges';
 import DetailMetadata from './DetailMetadata';
 import NextUpCard from './NextUpCard';
+import {AnimeEpisodePills, AnimeItemPills} from '../../components/AnimeMarkerPills';
 
 import css from './Details.module.less';
 
@@ -116,6 +117,7 @@ const ClassicDetailScreen = ({
 						{endsAt && !isSeries && <span className={css.infoItem}>{endsAt}</span>}
 						{genres.length > 0 && <span className={css.infoItem}>{genres.slice(0, 3).join(' • ')}</span>}
 					</div>
+					<AnimeItemPills item={item} serverUrl={serverUrl} className={css.detailMarkers} />
 					{(techBadges.length > 0 || seerr.statusPills?.length > 0) && (
 						<div className={css.infoBadges}>
 							{techBadges.map((badge, i) => (
@@ -269,6 +271,7 @@ const ClassicDetailScreen = ({
 												{episodeRatings[ep.IndexNumber].toFixed(1)}
 											</span>
 										)}
+										<AnimeEpisodePills episode={ep} serverUrl={serverUrl} compact className={css.episodeMarkers} />
 									</div>
 								</SpottableDiv>
 							);

--- a/packages/app/src/views/Details/Details.module.less
+++ b/packages/app/src/views/Details/Details.module.less
@@ -281,6 +281,10 @@
 	margin-top: 9px;
 }
 
+.detailMarkers {
+	margin-top: 9px;
+}
+
 /* Media Badges */
 .badge {
 	padding: 3px 9px;
@@ -893,6 +897,12 @@
 .episodeEpRuntime {
 	font-size: 14px;
 	color: rgba(255, 255, 255, 0.4);
+	flex-shrink: 0;
+}
+
+// The episode title is what gives way when the row runs out of room, so the markers hold
+// their width the same way the runtime and the rating do.
+.episodeMarkers {
 	flex-shrink: 0;
 }
 
@@ -1890,4 +1900,10 @@
 }
 
 .nextUpInfo { .flex-col-gap(6px); }
+
+// Under the title rather than beside it: the title already ellipses at this width, so
+// anything sharing its line would be the half that gets cut.
+.nextUpMarkers {
+	align-self: flex-start;
+}
 

--- a/packages/app/src/views/Details/ModernDetailContent.js
+++ b/packages/app/src/views/Details/ModernDetailContent.js
@@ -19,6 +19,7 @@ import {DETAIL_ICON_PATHS} from './detailIcons';
 import {iconViewBox} from '../../components/icons/iconViewBox';
 import {personalRatingIconPath, personalRatingLabel} from './personalRatingAction';
 import {arrange, seerrOnlyRow, DETAIL_ORDER_KEY, DETAIL_HIDDEN_KEY} from '../../utils/buttonLayout';
+import {AnimeEpisodePills, AnimeItemPills} from '../../components/AnimeMarkerPills';
 
 import css from './ModernDetailContent.module.less';
 
@@ -374,6 +375,7 @@ const ModernDetailContent = (props) => {
 						<div className={css.episodeBody}>
 							<span className={css.episodeName}>{label}</span>
 							{epRuntime && <span className={css.episodeMeta}>{epRuntime}</span>}
+							<AnimeEpisodePills episode={ep} serverUrl={effectiveServerUrl} large />
 							{ep.Overview && !hidesMediaDescription(ep, settings) && <p className={css.episodeOverview}>{ep.Overview}</p>}
 						</div>
 					</SpottableDiv>
@@ -715,6 +717,7 @@ const ModernDetailContent = (props) => {
 					<SeerrStatusBadge seerr={seerr} className={css.metaBadge} />
 				</div>
 			)}
+			<AnimeItemPills item={item} serverUrl={effectiveServerUrl} large />
 			{hasTech && (
 				<div className={css.techRow}>
 					{techSize && <span className={css.techSize}>{techSize}</span>}

--- a/packages/app/src/views/Details/NextUpCard.js
+++ b/packages/app/src/views/Details/NextUpCard.js
@@ -3,6 +3,7 @@ import {useCallback} from 'react';
 import {getImageUrl} from '../../utils/helpers';
 import {hidesMediaDescription, seriesThumbUrl} from './detailsMedia';
 import {SpottableDiv, RowContainer} from './detailsSpottables';
+import {AnimeEpisodePills} from '../../components/AnimeMarkerPills';
 
 import css from './Details.module.less';
 
@@ -43,6 +44,7 @@ const NextUpCard = ({episode, title, serverUrl, settings, onSelectItem}) => {
 				</div>
 				<div className={css.nextUpInfo}>
 					<span className={css.nextUpTitle}>{label ? `${label} - ${episode.Name}` : episode.Name}</span>
+					<AnimeEpisodePills episode={episode} serverUrl={serverUrl} className={css.nextUpMarkers} />
 					{!hideOverview && episode.Overview && <span className={css.nextUpOverview}>{episode.Overview}</span>}
 				</div>
 				<div className={css.nextUpPlayIcon}>

--- a/packages/app/src/views/Details/SeasonScreen.js
+++ b/packages/app/src/views/Details/SeasonScreen.js
@@ -8,6 +8,7 @@ import {DETAIL_ICON_PATHS} from './detailIcons';
 import {SpottableDiv, HorizontalContainer} from './detailsSpottables';
 import {handleSeasonButtonKeyDown} from './detailsFocus';
 import {PosterBadges, WatchedCheckIcon, FavoriteHeartIcon} from './DetailBadges';
+import {AnimeEpisodePills} from '../../components/AnimeMarkerPills';
 
 import css from './Details.module.less';
 
@@ -133,6 +134,7 @@ const SeasonScreen = ({
 											{episodeRatings[ep.IndexNumber].toFixed(1)}
 										</span>
 									)}
+									<AnimeEpisodePills episode={ep} serverUrl={serverUrl} compact />
 								</span>
 							</div>
 							<span className={css.seasonEpTitle}>{ep.Name}</span>

--- a/packages/app/src/views/Player/NextUpOverlay.js
+++ b/packages/app/src/views/Player/NextUpOverlay.js
@@ -1,6 +1,7 @@
 import $L from '@enact/i18n/$L';
 import {SpottableButton} from './PlayerConstants';
 import {CountdownRing, PlayGlyph, formatRemaining, useOverlayFocus} from './overlayParts';
+import AnimeMarkerPills, {useEpisodeMarker, hasAnimeMarkerPills} from '../../components/AnimeMarkerPills';
 
 import css from './NextUpOverlay.module.less';
 
@@ -21,13 +22,14 @@ const episodeLabel = (episode) => {
  * play button rather than under the card, so the countdown reads as part of the
  * thing it is about to do.
  */
-const NextUpOverlay = ({episode, imageUrl, countdown, timeout, countdownStyle, minimal, onPlay, onDismiss}) => {
+const NextUpOverlay = ({episode, imageUrl, serverUrl, countdown, timeout, countdownStyle, minimal, onPlay, onDismiss}) => {
 	useOverlayFocus('next-up-play-btn');
 
 	const counting = countdown != null && timeout > 0;
 	const showRing = counting && (countdownStyle === 'progressBar' || countdownStyle === 'both');
 	const showTimer = counting && (countdownStyle === 'timer' || countdownStyle === 'both');
 	const pill = episodeLabel(episode);
+	const marker = useEpisodeMarker(episode, {serverUrl});
 
 	return (
 		<div className={`${css.overlay} ${minimal ? css.minimal : ''}`}>
@@ -40,7 +42,12 @@ const NextUpOverlay = ({episode, imageUrl, countdown, timeout, countdownStyle, m
 				)}
 				<div className={css.info}>
 					<div className={css.eyebrow}>{$L('Up Next')}</div>
-					{pill && <div className={css.pill}>{pill}</div>}
+					{(pill || hasAnimeMarkerPills(marker)) && (
+						<div className={css.pills}>
+							{pill && <div className={css.pill}>{pill}</div>}
+							<AnimeMarkerPills marker={marker} />
+						</div>
+					)}
 					<div className={css.title}>{episode?.Name}</div>
 					{showTimer && (
 						<div className={css.timer}>

--- a/packages/app/src/views/Player/NextUpOverlay.module.less
+++ b/packages/app/src/views/Player/NextUpOverlay.module.less
@@ -81,8 +81,16 @@
 	font-size: 16px;
 }
 
-.pill {
+.pills {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	flex-wrap: wrap;
+	.flex-wrap-gap(6px; 8px);
 	margin-top: 10px;
+}
+
+.pill {
 	padding: 3px 12px;
 	border-radius: 9px;
 	font-size: 16px;

--- a/packages/app/src/views/Player/TizenPlayer.js
+++ b/packages/app/src/views/Player/TizenPlayer.js
@@ -2925,6 +2925,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 					<NextUpOverlay
 						episode={nextEpisode}
 						imageUrl={getImageUrl(item._serverUrl || getServerUrl(), nextEpisode.Id, 'Primary', {maxWidth: 400, quality: 80})}
+						serverUrl={item._serverUrl || getServerUrl()}
 						countdown={nextEpisodeCountdown}
 						timeout={settings.nextUpTimeout ?? 7}
 						countdownStyle={settings.nextUpCountdownStyle ?? 'both'}

--- a/packages/app/src/views/Player/WebOSPlayer.js
+++ b/packages/app/src/views/Player/WebOSPlayer.js
@@ -2858,6 +2858,7 @@ const Player = ({item, resume, initialMediaSourceId, initialAudioIndex, initialS
 					<NextUpOverlay
 						episode={nextEpisode}
 						imageUrl={getImageUrl(item._serverUrl || getServerUrl(), nextEpisode.Id, 'Primary', {maxWidth: 400, quality: 80})}
+						serverUrl={item._serverUrl || getServerUrl()}
 						countdown={nextEpisodeCountdown}
 						timeout={settings.nextUpTimeout ?? 7}
 						countdownStyle={settings.nextUpCountdownStyle ?? 'both'}


### PR DESCRIPTION
# Pull Request

## Summary
Anime Markers for SmartTv based on Plugin update made by me.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #
- https://github.com/Moonfin-Client/Plugin/pull/281

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Changed UI for Movie/Shows to only load pills when enabled in plugin
- Next up also loads then Markers
- Updaed lock file for Tizen

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Sideloaded Moonfin
2. Tested if rection time is slower and if The Markers appear as expected
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="1536" height="2048" alt="WhatsApp Image 2026-09-11 at 15 49 06 (1)" src="https://github.com/user-attachments/assets/2970ec49-4982-4472-b53d-66368a76fd7c" />
<img width="1536" height="2048" alt="WhatsApp Image 2026-09-11 at 15 49 06 (2)" src="https://github.com/user-attachments/assets/bb77a2e7-56e3-439d-93f9-ae9a99198474" />
<img width="1536" height="2048" alt="WhatsApp Image 2026-09-11 at 15 49 06" src="https://github.com/user-attachments/assets/f42bb4c6-fbd5-4d7b-b732-aa693d90b391" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
