### PR TITLE
Porting Genre Fixes to Smart-TV

### DIFF
--- a/packages/app/src/context/SettingsContext.js
+++ b/packages/app/src/context/SettingsContext.js
@@ -226,7 +226,7 @@ export const SYNCABLE_KEYS = [
 	'mediaBarOverlayColor', 'mediaBarOverlayOpacity',
 	'homeRows', 'homeRowsStyle', 'modernCardsOnMyMediaRow', 'detailScreenStyle', 'detailExpandedTabs', 'fullScreenRows', 'homeRowsPosterSize', 'useSeriesThumbnails',
 	'hideDetailsMediaDescription', 'detailUseSeriesThumbnails', 'hideHomeMediaDescription',
-	'personalRatingStyle', 'recentlyReleasedSeriesType', 'mergeRecentRowsByType', 'playlistsGroupByType',
+	'personalRatingStyle', 'recentlyReleasedSeriesType', 'mergeRecentRowsByType', 'playlistsGroupByType', 'groupItemsIntoCollections',
 	'useDetailedSubHeadings', 'showMediaDetailsOnLibraryPage', 'hideBackdropsInLibraries',
 	'syncplayEnabled', 'syncplayAutoOpen',
 	'showSyncPlayButton',

--- a/packages/app/src/context/defaultSettings.js
+++ b/packages/app/src/context/defaultSettings.js
@@ -116,6 +116,7 @@ export const defaultSettings = {
 	mergeContinueWatchingNextUp: true,
 	mergeRecentRowsByType: false,
 	playlistsGroupByType: true,
+	groupItemsIntoCollections: false,
 	nextUpMaxDays: 365,
 	hiddenContinueWatchingItems: null,
 	hiddenNextUpSeries: null,

--- a/packages/app/src/context/settingsSync.test.js
+++ b/packages/app/src/context/settingsSync.test.js
@@ -153,4 +153,8 @@ describe('SYNCABLE_KEYS', () => {
 	test('includes seerrShowMissingCollectionItems', () => {
 		expect(SYNCABLE_KEYS).toContain('seerrShowMissingCollectionItems');
 	});
+
+	test('includes groupItemsIntoCollections', () => {
+		expect(SYNCABLE_KEYS).toContain('groupItemsIntoCollections');
+	});
 });

--- a/packages/app/src/views/GenreBrowse/GenreBrowse.js
+++ b/packages/app/src/views/GenreBrowse/GenreBrowse.js
@@ -106,6 +106,7 @@ const GenreBrowse = ({genre, libraryId, onSelectItem, backHandlerRef}) => {
 		}
 
 		try {
+			const groupCollections = Boolean(settings.groupItemsIntoCollections);
 			const [sortField, sortOrder] = sortBy.split(',');
 			const params = {
 				StartIndex: startIndex,
@@ -115,7 +116,8 @@ const GenreBrowse = ({genre, libraryId, onSelectItem, backHandlerRef}) => {
 				Recursive: true,
 				Genres: genre.name,
 				EnableTotalRecordCount: true,
-				CollapseBoxSetItems: false,
+				CollapseBoxSetItems: groupCollections,
+				ExcludeItemTypes: 'Playlist,Episode,Season,Folder',
 				Fields: 'ProductionYear,ImageTags,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesId,SeriesPrimaryImageTag,UserData'
 			};
 
@@ -124,9 +126,11 @@ const GenreBrowse = ({genre, libraryId, onSelectItem, backHandlerRef}) => {
 			}
 
 			if (filterType !== 'all') {
-				params.IncludeItemTypes = filterType;
+				params.IncludeItemTypes = groupCollections && (filterType === 'Movie' || filterType === 'Series')
+					? `${filterType},BoxSet`
+					: filterType;
 			} else {
-				params.IncludeItemTypes = 'Movie,Series';
+				params.IncludeItemTypes = groupCollections ? 'Movie,Series,BoxSet' : 'Movie,Series';
 			}
 
 			if (startLetter) {
@@ -201,7 +205,7 @@ const GenreBrowse = ({genre, libraryId, onSelectItem, backHandlerRef}) => {
 				setIsLoading(false);
 			}
 		}
-	}, [api, genre, libraryId, sortBy, filterType, startLetter, serverUrl, isRangeLoaded]);
+	}, [api, genre, libraryId, sortBy, filterType, startLetter, serverUrl, isRangeLoaded, settings.groupItemsIntoCollections]);
 
 	useEffect(() => {
 		if (genre) {

--- a/packages/app/src/views/Genres/Genres.js
+++ b/packages/app/src/views/Genres/Genres.js
@@ -134,12 +134,16 @@ const Genres = ({onSelectGenre, onHome, backHandlerRef}) => {
 					genreList = genresResult.Items || [];
 				}
 
+				const groupCollections = Boolean(settings.groupItemsIntoCollections);
 				const BATCH_SIZE = 10;
+				const usedBackdropIds = new Set();
 				const getGenreData = async (genre) => {
 					try {
 						const itemParams = {
 							Genres: genre.Name,
-							IncludeItemTypes: 'Movie,Series',
+							IncludeItemTypes: groupCollections ? 'Movie,Series,BoxSet' : 'Movie,Series',
+							ExcludeItemTypes: 'Playlist,Episode,Season,Folder',
+							CollapseBoxSetItems: groupCollections,
 							Recursive: true,
 							Limit: 5,
 							SortBy: 'Random',
@@ -175,13 +179,34 @@ const Genres = ({onSelectGenre, onHome, backHandlerRef}) => {
 						if (itemCount === 0) return null;
 
 						let backdropUrl = null;
+						let selectedBackdropId = null;
+
+						// First try to find a backdrop that hasn't been used yet across genre cards
 						for (const item of items) {
 							const backdropId = getBackdropId(item);
-							if (backdropId) {
+							if (backdropId && !usedBackdropIds.has(backdropId)) {
 								const itemServerUrl = item._serverUrl || serverUrl;
 								backdropUrl = getImageUrl(itemServerUrl, backdropId, 'Backdrop', {maxWidth: 780, quality: 80});
+								selectedBackdropId = backdropId;
 								break;
 							}
+						}
+
+						// If all items have already been used, fall back to any available backdrop
+						if (!backdropUrl) {
+							for (const item of items) {
+								const backdropId = getBackdropId(item);
+								if (backdropId) {
+									const itemServerUrl = item._serverUrl || serverUrl;
+									backdropUrl = getImageUrl(itemServerUrl, backdropId, 'Backdrop', {maxWidth: 780, quality: 80});
+									selectedBackdropId = backdropId;
+									break;
+								}
+							}
+						}
+
+						if (selectedBackdropId) {
+							usedBackdropIds.add(selectedBackdropId);
 						}
 
 						return {
@@ -218,7 +243,7 @@ const Genres = ({onSelectGenre, onHome, backHandlerRef}) => {
 		};
 
 		loadGenres();
-	}, [api, serverUrl, selectedLibrary, unifiedMode]);
+	}, [api, serverUrl, selectedLibrary, unifiedMode, settings.groupItemsIntoCollections]);
 
 	const sortedGenres = useMemo(() => {
 		const sorted = [...genres];

--- a/packages/app/src/views/Library/Library.js
+++ b/packages/app/src/views/Library/Library.js
@@ -297,14 +297,15 @@ const Library = ({library, genreFilter, studioFilter, onSelectItem, onViewPhoto,
 	groupCountRef.current = groups ? groups.length : 0;
 
 	const getItemTypeForLibrary = useCallback(() => {
-		if (!library) return 'Movie,Series';
+		const groupCollections = Boolean(settings.groupItemsIntoCollections);
+		if (!library) return groupCollections ? 'Movie,Series,BoxSet' : 'Movie,Series';
 		const collectionType = library.CollectionType?.toLowerCase();
 
 		switch (collectionType) {
 			case 'movies':
-				return 'Movie';
+				return groupCollections ? 'Movie,BoxSet' : 'Movie';
 			case 'tvshows':
-				return 'Series';
+				return groupCollections ? 'Series,BoxSet' : 'Series';
 			case 'boxsets':
 				return 'BoxSet';
 			case 'homevideos':
@@ -327,17 +328,21 @@ const Library = ({library, genreFilter, studioFilter, onSelectItem, onViewPhoto,
 			default:
 				return '';
 		}
-	}, [library, musicContentType]);
+	}, [library, musicContentType, settings.groupItemsIntoCollections]);
 
 	const getExcludeItemTypes = useCallback(() => {
+		const groupCollections = Boolean(settings.groupItemsIntoCollections);
+		if (isGenreMode) {
+			return groupCollections ? 'Playlist,Episode,Season,Folder' : 'BoxSet,Playlist,Episode,Season,Folder';
+		}
 		if (!library) return '';
 		const collectionType = library.CollectionType?.toLowerCase();
 
-		if (collectionType === 'movies' || collectionType === 'tvshows') {
+		if ((collectionType === 'movies' || collectionType === 'tvshows') && !groupCollections) {
 			return 'BoxSet';
 		}
 		return '';
-	}, [library]);
+	}, [library, isGenreMode, settings.groupItemsIntoCollections]);
 
 	const loadItems = useCallback(async (startIndex = 0, append = false) => {
 		if (!library && !genreFilter && !studioFilter) return;
@@ -431,7 +436,10 @@ const Library = ({library, genreFilter, studioFilter, onSelectItem, onViewPhoto,
 				if (excludeTypes) params.ExcludeItemTypes = excludeTypes;
 
 				const collectionType = library?.CollectionType?.toLowerCase();
-				if (collectionType === 'movies') params.CollapseBoxSetItems = false;
+				const groupCollections = Boolean(settings.groupItemsIntoCollections);
+				if (isGenreMode || collectionType === 'movies' || collectionType === 'tvshows') {
+					params.CollapseBoxSetItems = groupCollections;
+				}
 
 				if (filters.length > 0) params.Filters = filters.join(',');
 				if (seriesStatusParam) params.SeriesStatus = seriesStatusParam;
@@ -477,7 +485,8 @@ const Library = ({library, genreFilter, studioFilter, onSelectItem, onViewPhoto,
 				let newItems = result.Items || [];
 
 				if (excludeTypes && newItems.length > 0) {
-					newItems = newItems.filter(item => item.Type !== 'BoxSet');
+					const excludedList = excludeTypes.split(',').map(t => t.trim());
+					newItems = newItems.filter(item => !excludedList.includes(item.Type));
 				}
 
 				apiFetchIndexRef.current = append ? apiFetchIndexRef.current + (result.Items?.length || 0) : (result.Items?.length || 0);
@@ -494,7 +503,7 @@ const Library = ({library, genreFilter, studioFilter, onSelectItem, onViewPhoto,
 			setIsLoading(false);
 			loadingMoreRef.current = false;
 		}
-	}, [isPlaylistLibrary, effectiveApi, library, genreFilter, studioFilter, sortKey, sortOrder, favoritesOnly, playedFilter, likedFilter, seriesFilter, featureFilters, qualityFilters, videoSourceFilters, genreFilters, ratingFilters, tagFilters, yearFilters, audioLanguageFilters, subtitleLanguageFilters, isFolderView, currentFolderId, currentFolderCollectionType, isMusicLibrary, musicContentType, getItemTypeForLibrary, getExcludeItemTypes]);
+	}, [isPlaylistLibrary, effectiveApi, library, genreFilter, studioFilter, sortKey, sortOrder, favoritesOnly, playedFilter, likedFilter, seriesFilter, featureFilters, qualityFilters, videoSourceFilters, genreFilters, ratingFilters, tagFilters, yearFilters, audioLanguageFilters, subtitleLanguageFilters, isFolderView, currentFolderId, currentFolderCollectionType, isMusicLibrary, musicContentType, getItemTypeForLibrary, getExcludeItemTypes, settings.groupItemsIntoCollections, isGenreMode]);
 
 	loadItemsRef.current = loadItems;
 
@@ -581,7 +590,7 @@ const Library = ({library, genreFilter, studioFilter, onSelectItem, onViewPhoto,
 			initialFocusDoneRef.current = false;
 			loadItemsRef.current(0, false);
 		}
-	}, [library, sortKey, sortOrder, favoritesOnly, playedFilter, likedFilter, seriesFilter, featureFilters, qualityFilters, videoSourceFilters, genreFilters, ratingFilters, tagFilters, yearFilters, audioLanguageFilters, subtitleLanguageFilters, musicContentType, isFolderView, currentFolderId, genreFilter, studioFilter, isMusicBrowseHome]);
+	}, [library, sortKey, sortOrder, favoritesOnly, playedFilter, likedFilter, seriesFilter, featureFilters, qualityFilters, videoSourceFilters, genreFilters, ratingFilters, tagFilters, yearFilters, audioLanguageFilters, subtitleLanguageFilters, musicContentType, isFolderView, currentFolderId, genreFilter, studioFilter, isMusicBrowseHome, settings.groupItemsIntoCollections]);
 
 	// The values the library actually holds, read once per library so opening
 	// the filter panel does not wait on the network.

--- a/packages/app/src/views/Library/Library.module.less
+++ b/packages/app/src/views/Library/Library.module.less
@@ -37,9 +37,9 @@
 }
 
 .headerSide {
-	width: 464px;
-	-webkit-flex: 0 0 auto;
-	flex: 0 0 auto;
+	width: 380px;
+	-webkit-flex: 0 0 380px;
+	flex: 0 0 380px;
 }
 
 .headerTitle {
@@ -52,6 +52,7 @@
 	-webkit-justify-content: center;
 	justify-content: center;
 	min-width: 0;
+	padding: 0 16px;
 }
 
 .searchWrap {
@@ -70,6 +71,10 @@
 	font-size: 38px;
 	font-weight: 300;
 	color: var(--theme-text-primary, white);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 .itemCount {
@@ -78,6 +83,8 @@
 	color: rgba(var(--theme-on-surface-rgb, 255, 255, 255), 0.4);
 	margin-left: 17px;
 	font-weight: 400;
+	white-space: nowrap;
+	flex-shrink: 0;
 }
 
 /* ── Breadcrumb (folder view) ────────────────────────────── */

--- a/packages/app/src/views/Settings/settingsSchema.js
+++ b/packages/app/src/views/Settings/settingsSchema.js
@@ -439,6 +439,7 @@ export const SETTINGS_SCHEMA = [
 					{kind: KIND.TOGGLE, key: 'unifiedLibraryMode', label: () => $L('Multi-Server Libraries'), desc: () => $L('Show libraries from all connected servers'), icon: 'dns'},
 					{kind: KIND.OPTION, key: 'recentlyReleasedSeriesType', label: () => $L('Recently Released Series Sort By'), desc: () => $L('Sort Recently Released Series home rows by series, latest season, or latest episode air date'), options: getRecentlyReleasedSeriesTypeOptions, fallback: () => $L('Series'), icon: 'tv'},
 					{kind: KIND.SECTION, id: 'libraryView', label: () => $L('Library View')},
+					{kind: KIND.TOGGLE, key: 'groupItemsIntoCollections', label: () => $L('Group into Collections'), desc: () => $L('Group movies and series into collections when browsing libraries and genres.'), icon: 'photo_library'},
 					{kind: KIND.TOGGLE, key: 'showMediaDetailsOnLibraryPage', label: () => $L('Show Media Details'), desc: () => $L('Show details of the selected item at the top of Library pages.'), icon: 'info'},
 					{kind: KIND.TOGGLE, key: 'hideBackdropsInLibraries', label: () => $L('Hide Backdrops while Browsing?'), desc: () => $L('Hide backdrops when browsing libraries'), icon: 'hide_image'}
 				]


### PR DESCRIPTION
# Pull Request

## Summary
Brings the genre catalog browsing and collection grouping behavior in Moonfin-Smart-TV into parity with Moonfin-Core. This adds support for the groupItemsIntoCollections setting in Smart-TV, ensures genre views dynamically include boxsets and collapse collection items when enabled, excludes non-browsable item types (playlists, episodes, seasons, folders), deduplicates random genre backdrop artwork, and resolves a header layout issue where multi-word titles and item counts wrapped awkwardly onto multiple lines.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # Port of https://github.com/Moonfin-Client/Moonfin-Core/pull/1522

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **defaultSettings.js**: Added groupItemsIntoCollections: false default setting.
- **SettingsContext.js**: Added 'groupItemsIntoCollections' to SYNCABLE_KEYS to enable settings synchronization with Moonbase and other clients.
- **settingsSync.test.js**: Added test asserting groupItemsIntoCollections is registered in SYNCABLE_KEYS.
- **settingsSchema.js**: Added "Group into Collections" switch toggle under the Library View settings panel.
- **GenreBrowse.js**: Added CollapseBoxSetItems: Boolean(settings.groupItemsIntoCollections), dynamically included BoxSet in IncludeItemTypes when grouping is active, added ExcludeItemTypes: 'Playlist,Episode,Season,Folder', and added settings.groupItemsIntoCollections to dependency arrays.
- **Genres.js**: Updated itemParams to evaluate settings.groupItemsIntoCollections dynamically for item counts and types, added settings.groupItemsIntoCollections to the effect dependencies, and introduced usedBackdropIds tracking so genre tiles pick distinct, random backdrop thumbnails without visual repetition across cards.
- **Library.js**:
  - Updated getItemTypeForLibrary to include BoxSet when collections grouping is enabled for movies, TV shows, and global genre browse.
  - Updated getExcludeItemTypes to exclude Playlist,Episode,Season,Folder in genre mode, and only exclude BoxSet when grouping is off.
  - Updated loadItems to dynamically set CollapseBoxSetItems based on groupItemsIntoCollections when in genre mode or movie/tv libraries, and properly evaluate excludeTypes without hardcoded boxset drops.
  - Added settings.groupItemsIntoCollections and isGenreMode to dependency arrays for reactive reloading.
- **Library.module.less**:
  - Reduced .headerSide width from 464px to 380px to reserve ~170px of extra breathing room for the center header container.
  - Added white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; to .libraryTitle so titles remain strictly on a single line.
  - Added white-space: nowrap; flex-shrink: 0; to .itemCount so counts never wrap or get squeezed by adjacent elements.
  - Added padding: 0 16px; to .headerTitle for balanced spacing between title elements and side panels.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. Launch Moonfin on Smart-TV and navigate to Settings > Library View.
2. Toggle "Group into Collections" ON.
3. Open the global Genres catalog:
   - Confirm genre item counts match grouped counts.
   - Confirm genre tile backdrop art is deduplicated across cards.
4. Select a genre (e.g. "Science Fiction"):
   - Confirm top header displays title and count on a single line ("Science Fiction 214 Items") without line wrapping or squishing against search.
   - Confirm items are grouped into collections (boxsets collapsed).
   - Confirm playlists, seasons, and episodes are excluded.
5. Toggle "Group into Collections" OFF and verify genre page and library views reactively refresh with ungrouped counts and individual items.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Group Collections Setting
<img width="2257" height="1182" alt="2026-09-12_10-42-29_brave" src="https://github.com/user-attachments/assets/ed26c22c-1f57-4998-b41c-24fd559239dd" />

### Collection Grouping On
<img width="2544" height="1182" alt="2026-09-12_10-38-57" src="https://github.com/user-attachments/assets/a1ee9484-eabf-4982-8823-c35b63dc418e" />
<img width="2544" height="1182" alt="2026-09-12_10-39-03" src="https://github.com/user-attachments/assets/bbb49923-f0a3-4261-aa41-2eeb4e350269" />

### Collection Grouping Off
<img width="2544" height="1182" alt="2026-09-12_10-39-09" src="https://github.com/user-attachments/assets/f41c721d-2071-45d1-a211-81d37c2a6283" />
<img width="2544" height="1182" alt="2026-09-12_10-39-15" src="https://github.com/user-attachments/assets/bcab79bc-2408-420d-9390-b63a013b6151" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
