### PR TITLE
bugfix-homescreen - Fix TV series normalization within Latest Media rows

### DIFF
--- a/packages/app/src/components/MediaCard/MediaCard.js
+++ b/packages/app/src/components/MediaCard/MediaCard.js
@@ -207,7 +207,7 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', rowImageType = 'post
 	const showUnplayedCount = showIndicators && watchedBehavior !== 'hideCount' && !item.UserData?.Played && unplayedCount > 0;
 
 	const displayTitle = useMemo(() => {
-		if (item.Type === 'Episode') {
+		if (item.Type === 'Episode' || item.Type === 'Season') {
 			return item.SeriesName || item.Name;
 		}
 		return item.Name;
@@ -217,8 +217,11 @@ const MediaCard = ({item, serverUrl, cardType = 'portrait', rowImageType = 'post
 		if (item.Type === 'Episode' && item.ParentIndexNumber !== undefined) {
 			return `S${item.ParentIndexNumber}:E${item.IndexNumber} - ${item.Name}`;
 		}
+		if (item.Type === 'Season' && item.SeriesName) {
+			return item.Name;
+		}
 		return null;
-	}, [item.Type, item.ParentIndexNumber, item.IndexNumber, item.Name]);
+	}, [item.Type, item.ParentIndexNumber, item.IndexNumber, item.Name, item.SeriesName]);
 
 	const musicInfo = useMemo(() => {
 		if (item.Type === 'MusicAlbum') {

--- a/packages/app/src/components/MediaCard/ModernMediaCard.js
+++ b/packages/app/src/components/MediaCard/ModernMediaCard.js
@@ -6,7 +6,7 @@ import RatingsRow from '../RatingsRow';
 import {getImageUrl} from '../../utils/helpers';
 import {useSettings} from '../../context/SettingsContext';
 import {getPlatform} from '../../platform';
-import {isStaticLibraryCard, modernCardMetrics} from './modernCardLayout';
+import {isStaticLibraryCard, modernCardMetrics, getEpisodeLabels, getCardDisplayTitle} from './modernCardLayout';
 import SeerrIcon from '../icons/SeerrIcon';
 
 import css from './ModernMediaCard.module.less';
@@ -51,19 +51,6 @@ const getMetadataLine = (item) => {
 	const runtime = formatRuntime(item.RunTimeTicks);
 	if (runtime) parts.push(runtime);
 	return parts.join(' • ');
-};
-
-// Short form rests under the title, the full form takes over while focused. The
-// episode title only joins in when the series name occupies the main title, since
-// without a SeriesName the title already is item.Name and would repeat here.
-const getEpisodeLabels = (item) => {
-	if (!item || item.Type !== 'Episode') return null;
-	if (!Number.isFinite(item.ParentIndexNumber) || !Number.isFinite(item.IndexNumber)) return null;
-	const short = `S${item.ParentIndexNumber}:E${item.IndexNumber}`;
-	return {
-		short,
-		full: item.SeriesName ? `${short} - ${item.Name}` : short
-	};
 };
 
 const ModernMediaCard = ({
@@ -248,11 +235,7 @@ const ModernMediaCard = ({
 	const unplayedCount = item?.UserData?.UnplayedItemCount;
 	const showUnplayedCount = showIndicators && watchedBehavior !== 'hideCount' && !item?.UserData?.Played && unplayedCount > 0;
 
-	const displayTitle = useMemo(() => {
-		if (!item) return '';
-		if (item.Type === 'Episode') return item.SeriesName || item.Name;
-		return item.Name;
-	}, [item]);
+	const displayTitle = useMemo(() => getCardDisplayTitle(item), [item]);
 
 	const metadata = useMemo(() => getMetadataLine(item), [item]);
 	const episodeLabels = useMemo(() => getEpisodeLabels(item), [item]);

--- a/packages/app/src/components/MediaCard/modernCardLayout.js
+++ b/packages/app/src/components/MediaCard/modernCardLayout.js
@@ -17,3 +17,30 @@ export const modernCardMetrics = ({posterSize, platform, isSquareItem, isStatic}
 
 	return {imageHeight, expandedWidth, cardWidth: isStatic ? expandedWidth : posterWidth};
 };
+
+export const getEpisodeLabels = (item) => {
+	if (!item) return null;
+	if (item.Type === 'Episode') {
+		if (!Number.isFinite(item.ParentIndexNumber) || !Number.isFinite(item.IndexNumber)) return null;
+		const short = `S${item.ParentIndexNumber}:E${item.IndexNumber}`;
+		return {
+			short,
+			full: item.SeriesName ? `${short} - ${item.Name}` : short
+		};
+	}
+	if (item.Type === 'Season' && item.SeriesName) {
+		return {
+			short: item.Name,
+			full: item.Name
+		};
+	}
+	return null;
+};
+
+export const getCardDisplayTitle = (item) => {
+	if (!item) return '';
+	if (item.Type === 'Episode' || item.Type === 'Season') {
+		return item.SeriesName || item.Name;
+	}
+	return item.Name;
+};

--- a/packages/app/src/components/MediaCard/modernCardLayout.test.js
+++ b/packages/app/src/components/MediaCard/modernCardLayout.test.js
@@ -1,4 +1,4 @@
-import {isStaticLibraryCard, modernCardMetrics} from './modernCardLayout';
+import {isStaticLibraryCard, modernCardMetrics, getCardDisplayTitle, getEpisodeLabels} from './modernCardLayout';
 
 const metrics = (over = {}) => modernCardMetrics({
 	posterSize: 'default',
@@ -58,5 +58,44 @@ describe('modernCardMetrics', () => {
 	test('Tizen grows wider than the web players do', () => {
 		expect(metrics({platform: 'tizen'}).expandedWidth).toBe(640);
 		expect(metrics({platform: 'webos'}).expandedWidth).toBe(594);
+	});
+});
+
+describe('Modern card labels and titles', () => {
+	test('renders SeriesName as title for Episode and Season items', () => {
+		expect(getCardDisplayTitle({Type: 'Episode', SeriesName: 'Party Down', Name: 'Pilot'})).toBe('Party Down');
+		expect(getCardDisplayTitle({Type: 'Season', SeriesName: 'Party Down', Name: 'Season 1'})).toBe('Party Down');
+		expect(getCardDisplayTitle({Type: 'Series', Name: 'Firefly'})).toBe('Firefly');
+		expect(getCardDisplayTitle({Type: 'Movie', Name: 'The Matrix'})).toBe('The Matrix');
+	});
+
+	test('falls back to item Name when SeriesName is absent', () => {
+		expect(getCardDisplayTitle({Type: 'Episode', Name: 'Pilot'})).toBe('Pilot');
+		expect(getCardDisplayTitle({Type: 'Season', Name: 'Season 1'})).toBe('Season 1');
+	});
+
+	test('formats episode and season labels correctly', () => {
+		expect(getEpisodeLabels({
+			Type: 'Episode',
+			ParentIndexNumber: 1,
+			IndexNumber: 2,
+			SeriesName: 'Party Down',
+			Name: 'California College Conservative Union Caucus'
+		})).toEqual({
+			short: 'S1:E2',
+			full: 'S1:E2 - California College Conservative Union Caucus'
+		});
+
+		expect(getEpisodeLabels({
+			Type: 'Season',
+			SeriesName: 'Party Down',
+			Name: 'Season 1'
+		})).toEqual({
+			short: 'Season 1',
+			full: 'Season 1'
+		});
+
+		expect(getEpisodeLabels({Type: 'Movie', Name: 'The Matrix'})).toBeNull();
+		expect(getEpisodeLabels({Type: 'Series', Name: 'Firefly'})).toBeNull();
 	});
 });

--- a/packages/app/src/components/RatingsRow/RatingsRow.js
+++ b/packages/app/src/components/RatingsRow/RatingsRow.js
@@ -53,7 +53,7 @@ const RatingsRow = ({item, serverUrl, compact = false, pluginEnabled = true}) =>
 
 		const contentType = getContentType(item);
 		const tmdbId = getTmdbId(item);
-		if (!contentType || !tmdbId) {
+		if (!contentType || (!tmdbId && item.Type !== 'Series')) {
 			setAllRatings([]);
 			return;
 		}

--- a/packages/app/src/services/connectionPool.js
+++ b/packages/app/src/services/connectionPool.js
@@ -7,6 +7,7 @@
 import * as multiServerManager from './multiServerManager';
 import {createApiForServer} from './jellyfinApi';
 import {deduplicateMediaItems} from '../utils/mediaDedup';
+import {latestMediaFetchLimitForCollection} from '../utils/latestMediaRowNormalizer';
 
 /**
  * Execute a request to all servers and aggregate results
@@ -236,7 +237,8 @@ export const getLatestPerLibraryFromAllServers = async (excludedLibraryIds = [],
 			// Fetch latest for each library
 			await Promise.all(eligibleLibraries.map(async (lib) => {
 				try {
-					const latest = await api.getLatestMedia(lib.Id, 16);
+					const fetchLimit = latestMediaFetchLimitForCollection(lib.CollectionType, 16);
+					const latest = await api.getLatestMedia(lib.Id, fetchLimit);
 					if (latest && latest.length > 0) {
 						const taggedItems = latest.map(item => ({
 							...item,

--- a/packages/app/src/services/jellyfinApi.js
+++ b/packages/app/src/services/jellyfinApi.js
@@ -106,7 +106,7 @@ const CHANNEL_IDS_URL_LIMIT = 1800;
 
 const DEFAULT_TIMEOUT_MS = 15000;
 const PLAYBACK_TIMEOUT_MS = 120000;
-export const HOME_ROW_ITEM_FIELDS = 'DateCreated,PremiereDate,PrimaryImageAspectRatio,OfficialRating,Overview,Genres,GenreItems,ProductionYear,RunTimeTicks,CommunityRating,CriticRating,ProviderIds,ImageTags,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ParentThumbItemId,ParentLogoItemId,ParentLogoImageTag,SeriesPrimaryImageTag,SeriesName,ParentIndexNumber,IndexNumber,UserData,AlbumArtist,AlbumId,AlbumPrimaryImageTag';
+export const HOME_ROW_ITEM_FIELDS = 'DateCreated,PremiereDate,PrimaryImageAspectRatio,OfficialRating,Overview,Genres,GenreItems,ProductionYear,RunTimeTicks,CommunityRating,CriticRating,ProviderIds,ImageTags,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,ParentThumbItemId,ParentLogoItemId,ParentLogoImageTag,SeriesPrimaryImageTag,SeriesName,SeriesId,ParentIndexNumber,IndexNumber,UserData,AlbumArtist,AlbumId,AlbumPrimaryImageTag';
 
 // The home Next Up row asks the server for a window instead of the whole watch
 // history, which is what keeps the query fast on a large library. A series page

--- a/packages/app/src/services/mdblistApi.js
+++ b/packages/app/src/services/mdblistApi.js
@@ -102,9 +102,12 @@ const seriesTmdbIdCache = {};
  */
 export const resolveSeriesTmdbId = async (item) => {
 	if (!item) return null;
-	if (item.Type === 'Series') return getTmdbId(item);
+	if (item.Type === 'Series') {
+		const direct = getTmdbId(item);
+		if (direct) return direct;
+	}
 
-	const seriesId = item.SeriesId;
+	const seriesId = item.SeriesId || (item.Type === 'Series' ? item.Id : null);
 	if (!seriesId) return null;
 	if (seriesId in seriesTmdbIdCache) return seriesTmdbIdCache[seriesId];
 
@@ -157,7 +160,10 @@ const isNegativelyCached = (key) => {
 
 export const fetchRatings = async (serverUrl, item, options = {}) => {
 	const contentType = getContentType(item);
-	const tmdbId = getTmdbId(item);
+	let tmdbId = getTmdbId(item);
+	if (!tmdbId && item?.Type === 'Series' && (item.Id || item.SeriesId)) {
+		tmdbId = await resolveSeriesTmdbId(item);
+	}
 
 	if (!contentType || !tmdbId) return [];
 

--- a/packages/app/src/utils/latestMediaRowNormalizer.js
+++ b/packages/app/src/utils/latestMediaRowNormalizer.js
@@ -1,0 +1,83 @@
+// Normalizes Latest Media items from Jellyfin.
+// Jellyfin 12's /Items/Latest endpoint returns Season entities when an entire season
+// of a multi-season show is added, or Episode entities when individual episodes are added.
+// This normalizer collapses Season and Episode items into true Series cards with the
+// show's ID, name, and primary artwork, matching Moonfin-Core.
+
+export const latestMediaFetchLimitForCollection = (collectionType, defaultLimit = 16, maxLimit = 64) => {
+	const normalizedType = collectionType?.toLowerCase();
+	if (normalizedType === 'tvshows' || normalizedType === 'shows') {
+		const expanded = defaultLimit * 2;
+		return expanded > maxLimit ? maxLimit : expanded;
+	}
+	return defaultLimit;
+};
+
+export const seriesCardForLatestTvItem = (item) => {
+	if (!item) return null;
+	if (item.Type === 'Series') return item;
+	if (item.Type !== 'Episode' && item.Type !== 'Season') return null;
+
+	const seriesId = item.SeriesId || item.ParentId;
+	const seriesName = item.SeriesName?.trim();
+	if (!seriesId || !seriesName) return null;
+
+	const seriesPrimaryImageTag = item.SeriesPrimaryImageTag || item.ParentPrimaryImageTag;
+	const imageTags = {...(item.ImageTags || {})};
+	if (seriesPrimaryImageTag) {
+		imageTags.Primary = seriesPrimaryImageTag;
+	}
+
+	const normalized = {
+		...item,
+		Id: seriesId,
+		Type: 'Series',
+		Name: seriesName,
+		ImageTags: imageTags,
+		PrimaryImageTag: seriesPrimaryImageTag || item.PrimaryImageTag,
+		PrimaryImageItemId: seriesId
+	};
+
+	delete normalized.IndexNumber;
+	delete normalized.ParentIndexNumber;
+	// Do not retain season/episode-specific ProviderIds on the synthetic series card
+	delete normalized.ProviderIds;
+
+	if (item.Type === 'Episode') {
+		normalized.LatestEpisodeId = item.Id;
+		normalized.LatestEpisodePrimaryImageTag = item.ImageTags?.Primary || item.PrimaryImageTag;
+	}
+
+	return normalized;
+};
+
+export const collapseLatestTvItems = (items) => {
+	if (!Array.isArray(items)) return [];
+	const collapsed = [];
+	const seenIds = new Set();
+
+	for (const item of items) {
+		const normalized = seriesCardForLatestTvItem(item) || item;
+		if (!seenIds.has(normalized.Id)) {
+			seenIds.add(normalized.Id);
+			collapsed.push(normalized);
+		}
+	}
+
+	return collapsed;
+};
+
+export const normalizeLatestMediaItems = (items, {collectionType, limit = 16} = {}) => {
+	if (!Array.isArray(items)) return [];
+	const normalizedType = collectionType?.toLowerCase();
+	const isTvCollection = normalizedType === 'tvshows' || normalizedType === 'shows';
+	const hasTvItems = items.some((i) => i.Type === 'Episode' || i.Type === 'Season');
+	const shouldCollapse = isTvCollection || (!normalizedType && hasTvItems);
+
+	const normalized = shouldCollapse ? collapseLatestTvItems(items) : items;
+
+	if (limit && normalized.length > limit) {
+		return normalized.slice(0, limit);
+	}
+	return normalized;
+};

--- a/packages/app/src/utils/latestMediaRowNormalizer.test.js
+++ b/packages/app/src/utils/latestMediaRowNormalizer.test.js
@@ -1,0 +1,167 @@
+import {
+	latestMediaFetchLimitForCollection,
+	seriesCardForLatestTvItem,
+	collapseLatestTvItems,
+	normalizeLatestMediaItems
+} from './latestMediaRowNormalizer';
+
+describe('latestMediaRowNormalizer', () => {
+	describe('latestMediaFetchLimitForCollection', () => {
+		test('expands limit for tvshows and shows collections', () => {
+			expect(latestMediaFetchLimitForCollection('tvshows', 16, 64)).toBe(32);
+			expect(latestMediaFetchLimitForCollection('shows', 16, 64)).toBe(32);
+			expect(latestMediaFetchLimitForCollection('TVSHOWS', 16, 64)).toBe(32);
+		});
+
+		test('respects maxLimit when expanded limit exceeds it', () => {
+			expect(latestMediaFetchLimitForCollection('tvshows', 40, 50)).toBe(50);
+		});
+
+		test('returns defaultLimit for other types or null', () => {
+			expect(latestMediaFetchLimitForCollection('movies', 16, 64)).toBe(16);
+			expect(latestMediaFetchLimitForCollection('music', 16, 64)).toBe(16);
+			expect(latestMediaFetchLimitForCollection(null, 16, 64)).toBe(16);
+			expect(latestMediaFetchLimitForCollection(undefined, 16, 64)).toBe(16);
+		});
+	});
+
+	describe('seriesCardForLatestTvItem', () => {
+		test('returns item unchanged if already a Series', () => {
+			const seriesItem = {Id: 'series-1', Type: 'Series', Name: 'Firefly'};
+			expect(seriesCardForLatestTvItem(seriesItem)).toBe(seriesItem);
+		});
+
+		test('returns null for non-TV items', () => {
+			expect(seriesCardForLatestTvItem({Id: 'm1', Type: 'Movie', Name: 'The Matrix'})).toBeNull();
+		});
+
+		test('converts Season item to synthetic Series item', () => {
+			const seasonItem = {
+				Id: 'season-1',
+				Type: 'Season',
+				Name: 'Season 1',
+				SeriesId: 'series-party-down',
+				SeriesName: 'Party Down',
+				SeriesPrimaryImageTag: 'tag-series-1',
+				ImageTags: {Primary: 'tag-season-1'},
+				IndexNumber: 1,
+				ProviderIds: {Tmdb: '99999'}
+			};
+
+			const result = seriesCardForLatestTvItem(seasonItem);
+			expect(result).toEqual({
+				Id: 'series-party-down',
+				Type: 'Series',
+				Name: 'Party Down',
+				SeriesId: 'series-party-down',
+				SeriesName: 'Party Down',
+				SeriesPrimaryImageTag: 'tag-series-1',
+				ImageTags: {Primary: 'tag-series-1'},
+				PrimaryImageTag: 'tag-series-1',
+				PrimaryImageItemId: 'series-party-down'
+			});
+			expect(result.IndexNumber).toBeUndefined();
+			expect(result.ProviderIds).toBeUndefined();
+		});
+
+		test('falls back to ParentPrimaryImageTag and ParentId', () => {
+			const seasonItem = {
+				Id: 'season-2',
+				Type: 'Season',
+				Name: 'Season 2',
+				ParentId: 'series-misfits',
+				SeriesName: 'Misfits',
+				ParentPrimaryImageTag: 'parent-tag-1'
+			};
+
+			const result = seriesCardForLatestTvItem(seasonItem);
+			expect(result.Id).toBe('series-misfits');
+			expect(result.Name).toBe('Misfits');
+			expect(result.PrimaryImageTag).toBe('parent-tag-1');
+			expect(result.ImageTags.Primary).toBe('parent-tag-1');
+		});
+
+		test('converts Episode item to synthetic Series item with latest episode fields', () => {
+			const episodeItem = {
+				Id: 'ep-1',
+				Type: 'Episode',
+				Name: 'Pilot',
+				SeriesId: 'series-fleabag',
+				SeriesName: 'Fleabag',
+				SeriesPrimaryImageTag: 'tag-fleabag',
+				PrimaryImageTag: 'tag-ep-art',
+				ParentIndexNumber: 1,
+				IndexNumber: 1
+			};
+
+			const result = seriesCardForLatestTvItem(episodeItem);
+			expect(result.Id).toBe('series-fleabag');
+			expect(result.Type).toBe('Series');
+			expect(result.Name).toBe('Fleabag');
+			expect(result.LatestEpisodeId).toBe('ep-1');
+			expect(result.LatestEpisodePrimaryImageTag).toBe('tag-ep-art');
+			expect(result.IndexNumber).toBeUndefined();
+			expect(result.ParentIndexNumber).toBeUndefined();
+		});
+	});
+
+	describe('collapseLatestTvItems', () => {
+		test('deduplicates multiple seasons of the same show', () => {
+			const items = [
+				{Id: 'season-3', Type: 'Season', Name: 'Season 3', SeriesId: 'show-1', SeriesName: 'Party Down'},
+				{Id: 'season-2', Type: 'Season', Name: 'Season 2', SeriesId: 'show-1', SeriesName: 'Party Down'},
+				{Id: 'season-1', Type: 'Season', Name: 'Series 1', SeriesId: 'show-2', SeriesName: 'Misfits'}
+			];
+
+			const collapsed = collapseLatestTvItems(items);
+			expect(collapsed).toHaveLength(2);
+			expect(collapsed[0].Id).toBe('show-1');
+			expect(collapsed[0].Name).toBe('Party Down');
+			expect(collapsed[1].Id).toBe('show-2');
+			expect(collapsed[1].Name).toBe('Misfits');
+		});
+	});
+
+	describe('normalizeLatestMediaItems', () => {
+		test('collapses TV items when collectionType is tvshows or shows', () => {
+			const items = [
+				{Id: 's1', Type: 'Season', Name: 'Season 1', SeriesId: 'show-1', SeriesName: 'Party Down'}
+			];
+
+			const result = normalizeLatestMediaItems(items, {collectionType: 'tvshows'});
+			expect(result[0].Type).toBe('Series');
+			expect(result[0].Name).toBe('Party Down');
+		});
+
+		test('auto-detects TV items and collapses when collectionType is null', () => {
+			const items = [
+				{Id: 's1', Type: 'Season', Name: 'Season 1', SeriesId: 'show-1', SeriesName: 'Party Down'}
+			];
+
+			const result = normalizeLatestMediaItems(items);
+			expect(result[0].Type).toBe('Series');
+			expect(result[0].Name).toBe('Party Down');
+		});
+
+		test('does not collapse movie items', () => {
+			const items = [
+				{Id: 'm1', Type: 'Movie', Name: 'The Matrix'}
+			];
+
+			const result = normalizeLatestMediaItems(items, {collectionType: 'movies'});
+			expect(result[0].Type).toBe('Movie');
+			expect(result[0].Name).toBe('The Matrix');
+		});
+
+		test('respects limit argument', () => {
+			const items = [
+				{Id: 'm1', Type: 'Movie', Name: 'Movie 1'},
+				{Id: 'm2', Type: 'Movie', Name: 'Movie 2'},
+				{Id: 'm3', Type: 'Movie', Name: 'Movie 3'}
+			];
+
+			const result = normalizeLatestMediaItems(items, {collectionType: 'movies', limit: 2});
+			expect(result).toHaveLength(2);
+		});
+	});
+});

--- a/packages/app/src/views/Browse/browseRowLoaders.js
+++ b/packages/app/src/views/Browse/browseRowLoaders.js
@@ -3,6 +3,7 @@
 
 import $L from '@enact/i18n/$L';
 import {genericCollectionLabel, mergeRecentRows} from '../../utils/mergeRecentRows';
+import {latestMediaFetchLimitForCollection, normalizeLatestMediaItems} from '../../utils/latestMediaRowNormalizer';
 
 import {HOME_ROW_ITEM_FIELDS} from '../../services/jellyfinApi';
 import {loadSinceYouWatchedRows, loadRewatchItems} from '../../services/homeRecommendations';
@@ -117,7 +118,7 @@ const loadLatestAndRecentlyReleased = async (ctx) => {
 		const [latestResults, recentlyReleasedResults] = await Promise.all([
 			Promise.all(
 				eligibleLibraries.map(lib =>
-					api.getLatest(lib.Id, 16)
+					api.getLatest(lib.Id, latestMediaFetchLimitForCollection(lib.CollectionType, 16))
 						.then(latest => ({lib, latest}))
 						.catch(() => null)
 				)
@@ -135,7 +136,10 @@ const loadLatestAndRecentlyReleased = async (ctx) => {
 		if (settings.mergeRecentRowsByType) {
 			const latestEntries = latestResults
 				.filter((r) => r && r.latest?.length > 0)
-				.map((r) => ({lib: r.lib, items: r.latest}));
+				.map((r) => ({
+					lib: r.lib,
+					items: normalizeLatestMediaItems(r.latest, {collectionType: r.lib?.CollectionType, limit: 16})
+				}));
 			for (const merged of mergeRecentRows(latestEntries, 'DateCreated')) {
 				rows.push({
 					id: `latest-merged-${merged.collectionType}`,
@@ -162,16 +166,19 @@ const loadLatestAndRecentlyReleased = async (ctx) => {
 		}
 		for (const result of latestResults) {
 			if (result && result.latest?.length > 0) {
-				const libraryTitle = result.lib.Name;
-				const rowId = `latest-${result.lib.Id}`;
-				rows.push({
-					id: rowId,
-					title: $L('Recently Added {libraryName}').replace('{libraryName}', libraryTitle),
-					items: result.latest,
-					library: result.lib,
-					type: result.lib.CollectionType?.toLowerCase() === 'music' ? 'square' : 'portrait',
-					isLatestRow: true
-				});
+				const items = normalizeLatestMediaItems(result.latest, {collectionType: result.lib?.CollectionType, limit: 16});
+				if (items.length > 0) {
+					const libraryTitle = result.lib.Name;
+					const rowId = `latest-${result.lib.Id}`;
+					rows.push({
+						id: rowId,
+						title: $L('Recently Added {libraryName}').replace('{libraryName}', libraryTitle),
+						items,
+						library: result.lib,
+						type: result.lib.CollectionType?.toLowerCase() === 'music' ? 'square' : 'portrait',
+						isLatestRow: true
+					});
+				}
 			}
 		}
 		for (const result of recentlyReleasedResults) {

--- a/packages/app/src/views/Browse/useBrowseData.js
+++ b/packages/app/src/views/Browse/useBrowseData.js
@@ -7,6 +7,7 @@ import * as seerrApi from '../../services/seerrApi';
 import browseReducer, {browseInitialState, mergeRowsById} from './browseReducer';
 import {BROWSE_ROW_LOADERS, buildLoaderContext} from './browseRowLoaders';
 import {genericCollectionLabel, mergeRecentRows} from '../../utils/mergeRecentRows';
+import {normalizeLatestMediaItems} from '../../utils/latestMediaRowNormalizer';
 import {EXCLUDED_COLLECTION_TYPES, filterItemsByExcludedGenres} from './browseFilters';
 import {
 	CACHE_TTL_LIBRARIES, CACHE_TTL_VOLATILE, VOLATILE_REFRESH_COOLDOWN_MS,
@@ -409,7 +410,10 @@ const useBrowseData = ({
 					if (settings.mergeRecentRowsByType) {
 						const entries = latestResults
 							.filter((r) => r && r.latest?.length > 0)
-							.map((r) => ({lib: r.lib, items: r.latest}));
+							.map((r) => ({
+								lib: r.lib,
+								items: normalizeLatestMediaItems(r.latest, {collectionType: r.lib?.CollectionType, limit: 16})
+							}));
 						for (const merged of mergeRecentRows(entries, 'DateCreated')) {
 							newRows.push({
 								id: `latest-merged-${merged.collectionType}`,
@@ -422,19 +426,22 @@ const useBrowseData = ({
 					} else {
 						for (const result of latestResults) {
 							if (result && result.latest?.length > 0) {
-								const libraryTitle = result.lib._serverName
-									? `${result.lib.Name} (${result.lib._serverName})`
-									: result.lib.Name;
-								const rowId = `latest-${result.lib.Id}${result.lib._serverName ? '-' + result.lib._serverName : ''}`;
+								const items = normalizeLatestMediaItems(result.latest, {collectionType: result.lib?.CollectionType, limit: 16});
+								if (items.length > 0) {
+									const libraryTitle = result.lib._serverName
+										? `${result.lib.Name} (${result.lib._serverName})`
+										: result.lib.Name;
+									const rowId = `latest-${result.lib.Id}${result.lib._serverName ? '-' + result.lib._serverName : ''}`;
 
-								newRows.push({
-									id: rowId,
-									title: $L('Recently Added {libraryName}').replace('{libraryName}', libraryTitle),
-									items: result.latest,
-									library: result.lib,
-									type: result.lib.CollectionType?.toLowerCase() === 'music' ? 'square' : 'portrait',
-									isLatestRow: true
-								});
+									newRows.push({
+										id: rowId,
+										title: $L('Recently Added {libraryName}').replace('{libraryName}', libraryTitle),
+										items,
+										library: result.lib,
+										type: result.lib.CollectionType?.toLowerCase() === 'music' ? 'square' : 'portrait',
+										isLatestRow: true
+									});
+								}
 							}
 						}
 					}


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where Season items returned by Jellyfin in Latest Media rows or library views rendered generic season names (e.g., "Season 1", "Series 1") as the card title instead of the series name. In Jellyfin 12, `/Items/Latest` returns `Season` entities when recent items are added to a multi-season show. In Smart-TV, `MediaCard` and `ModernMediaCard` previously only inspected `item.Type === 'Episode'` when pulling `item.SeriesName` into the primary title slot. As a result, Season cards rendered "Season 1" as their primary title with empty subtitle/metadata lines. This PR introduces `latestMediaRowNormalizer.js` to collapse Season and Episode items into Series cards, expands fetch limits for TV libraries so collapsed rows remain complete, enables asynchronous series TMDB ID resolution in `RatingsRow` and `mdblistApi`, and ensures Season items rendered anywhere retain clean fallback titles.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # Port of https://github.com/Moonfin-Client/Moonfin-Core/pull/1529

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **packages/app/src/utils/latestMediaRowNormalizer.js**:
  - Implemented `normalizeLatestMediaItems`: Content-aware normalizer that collapses TV collections or lists containing `Episode`/`Season` items into clean `Series` cards.
  - Implemented `seriesCardForLatestTvItem`: Transforms `Season` and `Episode` items into synthetic `Series` cards with `Id: seriesId`, `Type: 'Series'`, `Name: seriesName`, `PrimaryImageTag: seriesPrimaryImageTag || parentPrimaryImageTag`, and `PrimaryImageItemId: seriesId`. Strips season-specific metadata and stale season `ProviderIds`.
  - Implemented `collapseLatestTvItems`: Deduplicates multiple seasons or episodes belonging to the same series.
  - Implemented `latestMediaFetchLimitForCollection`: Expands fetch limits for TV libraries (`'tvshows'` / `'shows'`) to 32 items so row density is preserved after deduplication.
- **packages/app/src/utils/latestMediaRowNormalizer.test.js**:
  - Comprehensive unit test suite covering fetch limit expansion, conversion of seasons and episodes into series cards, deduplication, and non-TV item preservation.
- **packages/app/src/views/Browse/browseRowLoaders.js**:
  - Integrated `latestMediaFetchLimitForCollection` and `normalizeLatestMediaItems` for both merged and per-library Latest Media rows.
- **packages/app/src/views/Browse/useBrowseData.js**:
  - Applied `normalizeLatestMediaItems` to multi-server / unified mode Latest rows.
- **packages/app/src/services/connectionPool.js**:
  - Used expanded fetch limit for TV libraries when loading latest items across servers.
- **packages/app/src/services/jellyfinApi.js**:
  - Added `SeriesId` to `HOME_ROW_ITEM_FIELDS` to ensure Jellyfin always returns `SeriesId` on Season and Episode items in home row queries.
- **packages/app/src/services/mdblistApi.js**:
  - Updated `resolveSeriesTmdbId` to resolve the show's TMDB ID using `item.Id` when `item.Type === 'Series'` but lacks pre-populated provider IDs.
  - Updated `fetchRatings` to asynchronously resolve `tmdbId` for Series cards.
- **packages/app/src/components/RatingsRow/RatingsRow.js**:
  - Allowed `Series` items without synchronous `tmdbId` to resolve ratings via `fetchRatings`.
- **packages/app/src/components/MediaCard/MediaCard.js**:
  - Updated `displayTitle` and `episodeInfo` so any standalone `Season` item displays the series name as primary title with season subtitle as secondary text.
- **packages/app/src/components/MediaCard/ModernMediaCard.js** & **modernCardLayout.js**:
  - Exported pure `getCardDisplayTitle` and `getEpisodeLabels` helpers supporting `Season` items.
  - Added unit test suite in **modernCardLayout.test.js**.

## Platform
- [ ] Tizen (Samsung)
- [ ] webOS (LG)
- [X] Both / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Ran unit test suite via `npm test -- --watchAll=false packages/app/src/components/MediaCard/modernCardLayout.test.js` (passed).
2. Ran full project test suite via `npm test -- --watchAll=false` (103/103 suites passed, 1,191 tests passed).
3. Ran Enact linter via `npx enact lint .` (0 errors, 0 warnings).
4. Ran image in emulator and looked at previously problematic entries.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Jellyfin 12 Mixtures (Seasons and Series; Seasons don't register ratings)
<img width="2243" height="901" alt="2026-09-12_15-39-26_brave" src="https://github.com/user-attachments/assets/bc3a0edf-e179-43a7-b689-bbdacd8834a3" />

### Moonfin Correction
<img width="2545" height="1046" alt="2026-09-12_15-48-03_WindowsTerminal" src="https://github.com/user-attachments/assets/ac5cffc4-4053-45e2-b869-da9aa024c871" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
